### PR TITLE
I couldn't `make` with simplejson in requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ restclient==0.11.0
 poster==0.7.0
 angeldust==0.1.3
 Markdown==2.3.1
-simplejson==3.3.0
 smartypants==1.6.0.3
 uuid==1.30
 psycopg2==2.5.1


### PR DESCRIPTION
This isn't even necessary with the version of python we're using, right?
