### PR TITLE
Add collection title to upload form

### DIFF
--- a/wardenclyffe/main/views.py
+++ b/wardenclyffe/main/views.py
@@ -647,10 +647,13 @@ class UploadFormView(StaffMixin, TemplateView):
         form.fields["collection"].queryset = Collection.objects.filter(
             active=True)
         collection_id = self.request.GET.get('collection', None)
+        collection_title = None
         if collection_id:
             collection = get_object_or_404(Collection, id=collection_id)
+            collection_title = collection.title
             form = collection.add_video_form()
-        return dict(form=form, collection_id=collection_id)
+        return dict(form=form, collection_id=collection_id,
+                    collection_title=collection_title)
 
 
 class ScanDirectoryView(StaffMixin, TemplateView):

--- a/wardenclyffe/templates/main/upload.html
+++ b/wardenclyffe/templates/main/upload.html
@@ -32,12 +32,18 @@
 {% endif %}
 		<div class="wc_help_button" id="help_video_source">?</div><!-- class="wc_help_button" -->
 	</div><!-- class="form_video_source" -->
-	<div class="form_video_collection">
-		<div class="form_video_collection_title">
-		 <label for="id_collection">Collection:</label>
-		</div>
-		{{ form.collection }}
-	</div><!-- class="form_video_collection" -->
+
+    <div class="form_video_collection">
+        <div class="form_video_collection_title">
+            <label for="id_collection">Collection:</label>
+        </div>
+        {% if form.collection %}
+            {{ form.collection }}
+        {% else %}
+            {{ collection_title }}
+        {% endif %}
+    </div><!-- class="form_video_collection" -->
+
 	<div class="visualclear"></div>
 </div><!-- class="panel_top" -->
 


### PR DESCRIPTION
In the case where you're uploading something from a collection detail
view, you get directed to a link like this:

```
http://localhost:8000/upload/?collection=28
```

Instead of displaying a blank "Collection:" label with no dropdown, we
can show the collection title here.
