### PR TITLE
Switch main encoding to aws

### DIFF
--- a/wardenclyffe/main/tasks.py
+++ b/wardenclyffe/main/tasks.py
@@ -383,6 +383,9 @@ def copy_from_s3_to_cunix(operation, params):
                      f.cap)
     operation.log(info="downloaded from S3")
     sftp_put(filename, suffix, t, video, "CUIT H264 %d" % resolution)
+    (operations, params) = video.handle_mediathread_submit()
+    for o in operations:
+        process_operation.delay(o, params)
     return ("complete", "")
 
 

--- a/wardenclyffe/mediathread/tests/test_views.py
+++ b/wardenclyffe/mediathread/tests/test_views.py
@@ -74,4 +74,4 @@ class TestSelectWorkflow(TestCase):
 
     @override_settings(MEDIATHREAD_PCP_WORKFLOW="foo3")
     def test_default(self):
-        self.assertEqual(select_workflow(False, False), "foo3")
+        self.assertEqual(select_workflow(False, False), None)

--- a/wardenclyffe/mediathread/views.py
+++ b/wardenclyffe/mediathread/views.py
@@ -59,9 +59,6 @@ def select_workflow(audio, audio2):
     if audio2:
         if hasattr(settings, 'MEDIATHREAD_AUDIO_PCP_WORKFLOW2'):
             return settings.MEDIATHREAD_AUDIO_PCP_WORKFLOW2
-    else:
-        if hasattr(settings, 'MEDIATHREAD_PCP_WORKFLOW'):
-            return settings.MEDIATHREAD_PCP_WORKFLOW
     return None
 
 


### PR DESCRIPTION
Switching over the main encoding path for mediathread (non-audio uploads) from PCP to ETS.

We were already submitting everything to S3/ETS in parallel anyway so basically, we just make `select_workflow()` only return workflows for audio uploads (thus never submitting a video upload to PCP), and then make sure that when the file has been transcoded, sent back to us, and we've copied it over from S3 up to CUNIX, we submit it to mediathread as WC normally would've done after getting the "done" signal from PCP.