### PR TITLE
merge audio and audio2

### DIFF
--- a/wardenclyffe/main/tests/test_models.py
+++ b/wardenclyffe/main/tests/test_models.py
@@ -293,11 +293,10 @@ class SubmitFilesTest(TestCase):
         u = UserFactory()
         v.make_mediathread_submit_file(
             "file.mp4", u, "course-id",
-            "http://example.com/", audio=False,
-            audio2=False)
+            "http://example.com/", audio=False)
         self.assertEquals(
             v.mediathread_submit(),
-            ("course-id", u.username, None, None))
+            ("course-id", u.username, None))
         v.clear_mediathread_submit()
         self.assertEquals(
             v.mediathread_submit(),
@@ -308,11 +307,10 @@ class SubmitFilesTest(TestCase):
         u = UserFactory()
         v.make_mediathread_submit_file(
             "file.mp4", u, "course-id",
-            "http://example.com/", audio=True,
-            audio2=True)
+            "http://example.com/", audio=True)
         self.assertEquals(
             v.mediathread_submit(),
-            ("course-id", u.username, u'True', u'True'))
+            ("course-id", u.username, u'True'))
         self.assertTrue(v.is_audio_file())
         v.clear_mediathread_submit()
         self.assertEquals(
@@ -346,7 +344,7 @@ class OperationTest(TestCase):
         u = UserFactory()
         (ops, params) = f.video.make_default_operations(
             "/tmp/file.mov",
-            f, u, True, True)
+            f, u, True)
         self.assertEquals(len(ops), 1)
         # just run these to get the coverage up. don't worry if they fail
         for (o, p) in zip(ops, params):

--- a/wardenclyffe/mediathread/tasks.py
+++ b/wardenclyffe/mediathread/tasks.py
@@ -5,8 +5,8 @@ from wardenclyffe.util.mail import send_mediathread_uploaded_mail
 from django_statsd.clients import statsd
 
 
-def guess_dimensions(video, audio2):
-    if audio2:
+def guess_dimensions(video, audio):
+    if audio:
         return 160, 120
     return video.get_dimensions()
 
@@ -21,7 +21,6 @@ def submit_to_mediathread(operation, params):
     user = operation.owner
     course_id = params['set_course']
     audio = params['audio']
-    audio2 = params['audio2']
     mediathread_secret = settings.MEDIATHREAD_SECRET
     mediathread_base = settings.MEDIATHREAD_BASE
     params = {
@@ -43,7 +42,7 @@ def submit_to_mediathread(operation, params):
         # default for audio uploads is the public streaming server
         params['mp3'] = mp3_url(video)
     else:
-        (width, height) = guess_dimensions(video, audio2)
+        (width, height) = guess_dimensions(video, audio)
         if not width or not height:
             statsd.incr(
                 "mediathread.tasks.submit_to_mediathread.failure.dimensions")
@@ -55,10 +54,8 @@ def submit_to_mediathread(operation, params):
         params['thumb'] = video.cuit_poster_url() or video.poster_url()
         if video.h264_secure_stream_url():
             # prefer h264 secure pseudo stream
-            if audio2:
+            if audio:
                 params['mp4_audio'] = video.h264_secure_stream_url()
-            else:
-                params['mp4_pseudo'] = video.h264_secure_stream_url()
             params["mp4-metadata"] = "w%dh%d" % (width, height)
         elif video.mediathread_url():
             # try flv pseudo stream as a fallback

--- a/wardenclyffe/mediathread/tests/test_views.py
+++ b/wardenclyffe/mediathread/tests/test_views.py
@@ -64,14 +64,10 @@ class TestInvalidSessions(TestCase):
 
 
 class TestSelectWorkflow(TestCase):
-    @override_settings(MEDIATHREAD_AUDIO_PCP_WORKFLOW="foo1")
+    @override_settings(MEDIATHREAD_AUDIO_PCP_WORKFLOW2="foo1")
     def test_audio(self):
-        self.assertEqual(select_workflow(True, False), "foo1")
+        self.assertEqual(select_workflow(True), "foo1")
 
-    @override_settings(MEDIATHREAD_AUDIO_PCP_WORKFLOW2="foo2")
-    def test_audio2(self):
-        self.assertEqual(select_workflow(False, True), "foo2")
-
-    @override_settings(MEDIATHREAD_PCP_WORKFLOW="foo3")
+    @override_settings(MEDIATHREAD_PCP_WORKFLOW2="foo3")
     def test_default(self):
-        self.assertEqual(select_workflow(False, False), None)
+        self.assertEqual(select_workflow(False), None)

--- a/wardenclyffe/templates/mediathread/mediathread.html
+++ b/wardenclyffe/templates/mediathread/mediathread.html
@@ -57,11 +57,7 @@
             
                     <form action="post/" method="post" enctype="multipart/form-data">
 {% if audio %}
-  {% if audio2 %}
-                    <input type="hidden" name="audio2" value="True" />
-  {% else %}
                     <input type="hidden" name="audio" value="True" />
-  {% endif %}
 {% endif %}
                     <div id="vitaldropform" class="adminformcontainer">
                         <table border="0" cellpadding="0" cellspacing="0" id="adminformtable" class="adminformtable"> 


### PR DESCRIPTION
audio2 used to mean 'mp3 -> mp4' instead of just plain mp3 uploading.

That has become the only approach that mediathread ever uses now,
so there's no more need for the two paths.

keeping 'audio' as the preferred parameter/flag, but always sending
audio files through the mp3 -> mp4 workflow.

I've basically gone through the code and anywhere that used the distinction,
flattened it to go that way. Then the mediathread API part is changed
so it accepts either 'audio' or 'audio2' parameters for
backwards compatibility.