### PR TITLE
:bug: move transaction.atomic decorator to post handler

### DIFF
--- a/wardenclyffe/main/views.py
+++ b/wardenclyffe/main/views.py
@@ -1318,7 +1318,6 @@ class SNSView(View):
             return HttpResponse("OK")
         return HttpResponse("Failed to confirm")
 
-    @transaction.atomic()
     def _notification(self, request):
         sp = transaction.savepoint()
         full_message = loads(self.body)
@@ -1376,6 +1375,7 @@ class SNSView(View):
 
         return HttpResponse("OK")
 
+    @transaction.atomic()
     def post(self, request):
         self.body = request.read()
         if 'HTTP_X_AMZ_SNS_MESSAGE_TYPE' not in self.request.META:


### PR DESCRIPTION
Been encountering an issue where copy s3 to cunix operations aren't being
executed automatically by celery. looking through the logs, i see that celery
tries, but can't retrieve the associated file object. that means it's a race
condition where celery is running the operation too quickly before a db transaction
in the web view has committed.

That's not supposed to happen, since the method that sets up the operation
is decorated with @transaction.atomic() and we make a savepoint, which is explicitly
committed before the operation is handed off to celery.

Reading the docs closely, I *think* what's happening is that for the SNS response
view, I decorated the _notification helper method with transaction.atomic (since
it's the one doing all the db work) instead of the post() method. The problem is that
without the post() method decorated, it defaults to django's AUTOCOMMIT behavior that
wraps the view in a transaction and commits on success. transaction.atomic() called
inside another transaction will nest and create a sub savepoint. So the savepoints
in _notification() are one level down. We commit that, but django still has an outer
transaction open.

I've moved the @transaction.atomic decorator over to the post() method itself,
which should disable AUTOCOMMIT for the view and make it only one level of transaction.

Anyway, I *think* this is the right analysis and fix, but I'm not 100% certain. Will
need to see how it actually goes in production (race conditions are no fun to reproduce...)