### PR TITLE
:bug: django 1.6+ transaction overhaul. PMT #99080

### DIFF
--- a/wardenclyffe/settings_production.py
+++ b/wardenclyffe/settings_production.py
@@ -27,6 +27,7 @@ DATABASES = {
         'PORT': 6432,  # 6432 = pgbouncer
         'USER': '',
         'PASSWORD': '',
+        'ATOMIC_REQUESTS': True,
         }
 }
 

--- a/wardenclyffe/settings_shared.py
+++ b/wardenclyffe/settings_shared.py
@@ -20,6 +20,7 @@ DATABASES = {
         'PORT': 5432,
         'USER': '',
         'PASSWORD': '',
+        'ATOMIC_REQUESTS': True,
     }
 }
 
@@ -34,6 +35,7 @@ if 'test' in sys.argv or 'jenkins' in sys.argv:
             'PORT': '',
             'USER': '',
             'PASSWORD': '',
+            'ATOMIC_REQUESTS': True,
         }
     }
     SURELINK_PROTECTION_KEY = "test-dummy-key"
@@ -97,7 +99,6 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
-    'django.middleware.transaction.TransactionMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware',
     'waffle.middleware.WaffleMiddleware',
 )

--- a/wardenclyffe/settings_staging.py
+++ b/wardenclyffe/settings_staging.py
@@ -27,6 +27,7 @@ DATABASES = {
         'PORT': 6432,  # 6432 = pgbouncer
         'USER': '',
         'PASSWORD': '',
+        'ATOMIC_REQUESTS': True,
         }
 }
 


### PR DESCRIPTION
Another approach to the transactions + celery issue.

After reading this carefully: https://realpython.com/blog/python/transaction-management-with-django-1-6/

I think I now understand what was going on.

First, we still had the old pre 1.6 transaction middleware running, which does
god knows what in a 1.6+ context.

Next, without that middleware running, the default behavior in Django is AUTOCOMMIT, which
means that each db query is wrapped in a transaction. That actually works
quite nicely for this particular case of Celery interaction, since
making sure that queries have been fully committed before the task is sent
to Celery is exactly what we want.

However, the rest of our code is still written under the assumption that each HTTP
request is wrapped in a transaction and will commit/rollback atomically based on
whether the view raises an exception. I think that's still what we want the vast
majority of the time, across most of our applications. This Celery situation is one
of the few places that we actually want AUTOCOMMIT behavior.

Django now, instead of the transaction middleware, has an 'ATOMIC_REQUESTS' setting that you
can configure where you set up your DB connection.

Once that is turned on, we are back to needing to manually escape from the atomic transactions
for our Celery views. Before, I thought the savepoints functionality was the way to achieve that.

Now I'm realizing that there's a simpler approach in just decorating the views with
`@transaction.non_atomic_request`, which switches behavior for that view back to the default
AUTOCOMMIT.

I've tested this locally and it seems to do things properly, so I'm going to run with it.