### PR TITLE
properly decorate CBVs with transaction.non_atomic_requests

### DIFF
--- a/wardenclyffe/mediathread/views.py
+++ b/wardenclyffe/mediathread/views.py
@@ -109,7 +109,6 @@ def mediathread_post(request):
                     tmpfilename, workflow, user)
                 operations.append(o)
                 params.append(p)
-
         except:
             statsd.incr("mediathread.mediathread.failure")
             raise


### PR DESCRIPTION
Turns out that decorating post() does nothing.

https://docs.djangoproject.com/en/1.7/topics/class-based-views/intro/\#decorating-the-class