### PR TITLE
Bulk operation resurrection

### DIFF
--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -169,6 +169,12 @@ class Video(TimeStampedModel):
             return f.mediathread_public_url()
         return ""
 
+    def h264_secure_stream_file(self):
+        for f in self.file_set.filter(location_type="cuit"):
+            if f.is_h264_secure_streamable():
+                return f
+        return None
+
     def h264_secure_stream_url(self):
         r = self.file_set.filter(location_type="cuit")
         if r.count() > 0:

--- a/wardenclyffe/main/tests/test_views.py
+++ b/wardenclyffe/main/tests/test_views.py
@@ -599,8 +599,10 @@ class TestStaff(TestCase):
         response = self.c.get("/bulk_file_operation/")
         self.assertEqual(response.status_code, 200)
 
-    def test_bulk_file_operation(self):
-        response = self.c.post("/bulk_file_operation/")
+    def test_bulk_file_operation_submit_to_pcp(self):
+        response = self.c.post(
+            "/bulk_file_operation/",
+            {'submit-to-pcp': 'yes'})
         self.assertEqual(response.status_code, 302)
 
     def test_video_add_file_form(self):

--- a/wardenclyffe/main/tests/test_views.py
+++ b/wardenclyffe/main/tests/test_views.py
@@ -596,15 +596,54 @@ class TestStaff(TestCase):
         response = self.c.post("/file/%d/submit_to_workflow/" % v.id)
         self.assertEqual(response.status_code, 302)
 
-    def test_bulk_file_operation_form(self):
+    def test_bulk_file_operation_form_empty(self):
         response = self.c.get(reverse('bulk-operation'))
         self.assertEqual(response.status_code, 200)
 
-    def test_bulk_file_operation_submit_to_pcp(self):
+    def test_bulk_file_operation_form(self):
+        v = VideoFactory()
+        response = self.c.get(
+            reverse('bulk-operation') + "?video_%d=on" % v.id)
+        self.assertEqual(response.status_code, 200)
+
+    def test_bulk_file_operation_submit_to_pcp_empty(self):
         response = self.c.post(
             reverse('bulk-operation'),
             {'submit-to-pcp': 'yes'})
         self.assertEqual(response.status_code, 302)
+
+    def test_bulk_file_operation_submit_to_pcp(self):
+        v = VideoFactory()
+        response = self.c.post(
+            reverse('bulk-operation') + "?video_%d=on" % v.id,
+            {'submit-to-pcp': 'yes'})
+        self.assertEqual(response.status_code, 302)
+
+    def test_bulk_file_operation_surelink_empty(self):
+        response = self.c.post(
+            reverse('bulk-operation'),
+            {'surelink': 'yes'})
+        self.assertRedirects(response, reverse('bulk-surelink'))
+
+    def test_bulk_file_operation_invalid(self):
+        response = self.c.post(
+            reverse('bulk-operation'))
+        self.assertEquals(response.status_code, 400)
+
+    def test_bulk_surelink_empty(self):
+        r = self.c.get(reverse('bulk-surelink'))
+        self.assertEqual(r.status_code, 200)
+
+    def test_bulk_surelink_video_not_surelinkable(self):
+        v = VideoFactory()
+        r = self.c.get(reverse('bulk-surelink') + "?video_%d=on" % v.id)
+        self.assertEqual(r.status_code, 200)
+
+    def test_bulk_surelink_video_surelinkable(self):
+        f = FileFactory()
+        v = f.video
+        r = self.c.get(reverse('bulk-surelink') + "?video_%d=on" % v.id)
+        self.assertEqual(r.status_code, 200)
 
     def test_video_add_file_form(self):
         v = VideoFactory()

--- a/wardenclyffe/main/tests/test_views.py
+++ b/wardenclyffe/main/tests/test_views.py
@@ -1,3 +1,4 @@
+from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.test.client import Client
@@ -596,12 +597,12 @@ class TestStaff(TestCase):
         self.assertEqual(response.status_code, 302)
 
     def test_bulk_file_operation_form(self):
-        response = self.c.get("/bulk_file_operation/")
+        response = self.c.get(reverse('bulk-operation'))
         self.assertEqual(response.status_code, 200)
 
     def test_bulk_file_operation_submit_to_pcp(self):
         response = self.c.post(
-            "/bulk_file_operation/",
+            reverse('bulk-operation'),
             {'submit-to-pcp': 'yes'})
         self.assertEqual(response.status_code, 302)
 

--- a/wardenclyffe/main/views.py
+++ b/wardenclyffe/main/views.py
@@ -1105,8 +1105,9 @@ class BulkOperationView(StaffMixin, View):
         return super(BulkOperationView, self).dispatch(*args, **kwargs)
 
     def _videos(self, request):
+        r = request.POST if request.method == "POST" else request.GET
         return [Video.objects.get(id=int(f.split("_")[1]))
-                for f in request.POST.keys() if f.startswith("video_")]
+                for f in r.keys() if f.startswith("video_")]
 
     def post(self, request):
         if request.POST.get('submit-to-pcp', False):

--- a/wardenclyffe/templates/cuit/broken_quicktime.html
+++ b/wardenclyffe/templates/cuit/broken_quicktime.html
@@ -7,10 +7,10 @@
 <script type="text/javascript">
 
 var selectAll = function()   {
-   $(".file_checkbox").attr('checked','checked');
+   $(".video_checkbox").attr('checked','checked');
 };
 var deselectAll = function() {
-   $(".file_checkbox").attr('checked','');
+   $(".video_checkbox").attr('checked','');
 };
 
 </script>
@@ -31,7 +31,7 @@ var deselectAll = function() {
 </tr>
 {% for file in broken_files %}
 <tr>
-<td><input class="file_checkbox" type="checkbox" name="file_{{file.id}}" /></td>
+<td><input class="video_checkbox" type="checkbox" name="video_{{file.video.id}}" /></td>
 <td><a href="{{file.get_absolute_url}}">{{file.filename}}</a></td>
 <td>{% if file.audio_format %}{{file.audio_format}}{% endif %}</td>
 <td>{% if file.video_format %}{{file.video_format}}{% endif %}</td>

--- a/wardenclyffe/templates/cuit/broken_quicktime.html
+++ b/wardenclyffe/templates/cuit/broken_quicktime.html
@@ -20,7 +20,7 @@ var deselectAll = function() {
 
 {% block content %}
 
-<form action="/bulk_file_operation/" method="get">
+<form action="{% url 'bulk-operation' %}" method="get">
 
 <table>
 <tr>

--- a/wardenclyffe/templates/main/bulk_file_operation.html
+++ b/wardenclyffe/templates/main/bulk_file_operation.html
@@ -2,19 +2,25 @@
 {% load markup %}
 
 {% block content %}
-<ul>
-{% for file in files %}
-<li>{{file.video.title}} {{file.label}}</li>
-{% endfor %}
-</ul>
+
+{% if files %}
+<h2>Bulk Operation with the following Files:</h2>
 
 
-
-{% if workflows %}
 <form action="." method="post">
+
 {% for file in files %}
 <input type="hidden" name="file_{{file.id}}" value="on" />
 {% endfor %}
+
+<table>
+{% for file in files %}
+<tr><td><a href="{{file.video.get_absolute_url}}">{{file.video.title}}</a></td><td><a href="{{file.get_absolute_url}}">{{file.label}}</a></td></tr>
+{% endfor %}
+</table>
+
+<h3>Submit to PCP</h3>
+{% if workflows %}
 <p>Submit <tt>{{file.video.title}}</tt> to workflow:<br />
 <select name="workflow">
 <option value="">select workflow</option>
@@ -23,11 +29,19 @@
 {% endfor %}
 </select>
 <br />
-<input type="submit" value="submit" />
-</form>
-
+<input type="submit" value="Submit Files to PCP" />
 {% else %}
-<p>Can't get a list of workflows. Is Kino up at <a href="{{kino_base}}">{{kino_base}}</a>?</p>
+<p>Can't get a list of workflows. PCP Submission not available.</p>
+<input disabled="disabled" type="submit" name="submit-to-pcp" value="Submit Files to PCP" />
+{% endif %}
+
+<h3>Surelink</h3>
+<p>Get surelink embed codes for all selected videos.</p>
+<input type="submit" value="Surelink" name="surelink" />
+
+</form>
+{% else %}
+<p>No files selected.</p>
 {% endif %}
 
 {% endblock %}

--- a/wardenclyffe/templates/main/bulk_operation.html
+++ b/wardenclyffe/templates/main/bulk_operation.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load markup %}
+{% load thumbnail %}
 
 {% block content %}
 
@@ -13,10 +14,37 @@
 <input type="hidden" name="video_{{video.id}}" value="on" />
 {% endfor %}
 
-<table>
+<table style="width: 100%" id="recent-videos" class="tablesorter"> 
+<thead>
+  <tr>
+    <th colspan="2">video</th>
+    <th>collection</th>
+    <th>uploaded</th>
+    <th>modified</th>
+  </tr>
+</thead>
+<tbody>
 {% for video in videos %}
-<tr><td><a href="{{video.get_absolute_url}}">{{video.title}}</a></td></tr>
+<tr class="{% cycle 'odd' 'even' %}">
+<td>
+<a href="{{video.get_absolute_url}}">{% with video.poster as poster %}
+{% if poster.dummy %}
+<img src="http://ccnmtl.columbia.edu/broadcast/posters/vidthumb_480x360.jpg"
+     width="160" height="120" />
+{% else %}
+{% thumbnail poster.image "160x120" as thmb %}
+<img src="{{thmb.absolute_url}}" />
+{% endif %}
+{% endwith %}</a>
+</td>
+<td align="left"><a href="{{video.get_absolute_url}}">{{video.title}}</a></td>
+<td><a href="{{video.collection.get_absolute_url}}">{{video.collection.title}}</a></td>
+<td><i>{{video.created|date:"M d, Y H:i:s"}}</i></td>
+<td><i>{{video.modified|date:"M d, Y H:i:s"}}</i></td>
+
+</tr>
 {% endfor %}
+</tbody>
 </table>
 
 <h3>Submit to PCP</h3>

--- a/wardenclyffe/templates/main/bulk_operation.html
+++ b/wardenclyffe/templates/main/bulk_operation.html
@@ -3,25 +3,25 @@
 
 {% block content %}
 
-{% if files %}
-<h2>Bulk Operation with the following Files:</h2>
+{% if videos %}
+<h2>Bulk Operation with the following Videos:</h2>
 
 
 <form action="." method="post">
 
-{% for file in files %}
-<input type="hidden" name="file_{{file.id}}" value="on" />
+{% for video in videos %}
+<input type="hidden" name="video_{{video.id}}" value="on" />
 {% endfor %}
 
 <table>
-{% for file in files %}
-<tr><td><a href="{{file.video.get_absolute_url}}">{{file.video.title}}</a></td><td><a href="{{file.get_absolute_url}}">{{file.label}}</a></td></tr>
+{% for video in videos %}
+<tr><td><a href="{{video.get_absolute_url}}">{{video.title}}</a></td></tr>
 {% endfor %}
 </table>
 
 <h3>Submit to PCP</h3>
 {% if workflows %}
-<p>Submit <tt>{{file.video.title}}</tt> to workflow:<br />
+<p>Submit videos to workflow:<br />
 <select name="workflow">
 <option value="">select workflow</option>
 {% for workflow in workflows %}
@@ -29,10 +29,10 @@
 {% endfor %}
 </select>
 <br />
-<input type="submit" value="Submit Files to PCP" />
+<input type="submit" value="Submit Videos to PCP" />
 {% else %}
 <p>Can't get a list of workflows. PCP Submission not available.</p>
-<input disabled="disabled" type="submit" name="submit-to-pcp" value="Submit Files to PCP" />
+<input disabled="disabled" type="submit" name="submit-to-pcp" value="Submit Videos to PCP" />
 {% endif %}
 
 <h3>Surelink</h3>
@@ -41,7 +41,7 @@
 
 </form>
 {% else %}
-<p>No files selected.</p>
+<p>No videos selected.</p>
 {% endif %}
 
 {% endblock %}

--- a/wardenclyffe/templates/main/bulk_surelink.html
+++ b/wardenclyffe/templates/main/bulk_surelink.html
@@ -1,0 +1,102 @@
+{% extends 'base.html' %}
+{% load thumbnail %}
+
+{% block js %}
+  {% include 'main/jquery.html' %}
+ 
+  <script type="text/javascript"> 
+     $(function(){
+       $('#tabs').tabs();
+     });
+  </script> 
+  
+  <style type="text/css"> 
+    body{ font: 72.5% "Trebuchet MS", sans-serif; margin: 50px;}
+  </style> 
+ 
+{% endblock %}
+
+
+{% block content %}
+
+<h2>Surelink for multiple videos</h2>
+<form action="." method="get">
+
+{% for video in videos %}
+<input type="hidden" name="video_{{video.id}}" value="on" />
+{% endfor %}
+
+<table style="width: 100%" id="recent-videos" class="tablesorter"> 
+<thead>
+  <tr>
+    <th colspan="2">video</th>
+    <th>collection</th>
+    <th>uploaded</th>
+    <th>modified</th>
+  </tr>
+</thead>
+<tbody>
+{% for video in videos %}
+<tr class="{% cycle 'odd' 'even' %}">
+<td>
+<a href="{{video.get_absolute_url}}">{% with video.poster as poster %}
+{% if poster.dummy %}
+<img src="http://ccnmtl.columbia.edu/broadcast/posters/vidthumb_480x360.jpg"
+     width="160" height="120" />
+{% else %}
+{% thumbnail poster.image "160x120" as thmb %}
+<img src="{{thmb.absolute_url}}" />
+{% endif %}
+{% endwith %}</a>
+</td>
+<td align="left"><a href="{{video.get_absolute_url}}">{{video.title}}</a></td>
+<td><a href="{{video.collection.get_absolute_url}}">{{video.collection.title}}</a></td>
+<td><i>{{video.created|date:"M d, Y H:i:s"}}</i></td>
+<td><i>{{video.modified|date:"M d, Y H:i:s"}}</i></td>
+
+</tr>
+{% endfor %}
+</tbody>
+</table>
+
+
+{% if surelinks %}
+
+<div class="ui-tabs ui-widget ui-widget-content ui-corner-all" id="tabs">
+  
+<ul class="ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header ui-corner-all">
+<li class="ui-state-default ui-corner-top"><a href="#tabs-2a">Better Iframe Embed</a></li>
+<li class="ui-state-default ui-corner-top"><a href="#tabs-3">Drupal *5* at ccnmtl</a></li>
+<li class="ui-state-default ui-corner-top"><a href="#tabs-4">GlobalMDP Study Embed</a></li>
+</ul>
+
+<div class="ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide" id="tabs-2a">
+  <textarea rows="{{rows}}" 
+  cols="100" style="width:100%">{% for surelink in surelinks %}{{surelink.iframe_embed}}
+{% endfor %}
+</textarea></div>
+
+<div class="ui-tabs-panel ui-widget-content ui-corner-bottom
+	    ui-tabs-hide" id="tabs-3">
+
+<textarea rows="{{rows}}" cols="100" 
+style="width:100%">{% for surelink in surelinks %}{{surelink.drupal_embed}}
+{% endfor %}
+</textarea></div>
+<div class="ui-tabs-panel ui-widget-content ui-corner-bottom
+	    ui-tabs-hide" id="tabs-4">
+<textarea rows="{{rows}}" cols="100" style="width:100%">
+{% for surelink in surelinks %}{{surelink.mdp_embed}}
+{% endfor %}</textarea>
+</div>
+</div>
+
+
+{% else %}
+<p>No surelinkable videos</p>
+{% endif %}
+
+
+
+
+{% endblock %}

--- a/wardenclyffe/templates/main/file_filter.html
+++ b/wardenclyffe/templates/main/file_filter.html
@@ -7,10 +7,10 @@
 <script type="text/javascript">
 
 var selectAll = function()   {
-   $(".file_checkbox").attr('checked','checked');
+   $(".video_checkbox").attr('checked','checked');
 };
 var deselectAll = function() {
-   $(".file_checkbox").attr('checked','');
+   $(".video_checkbox").attr('checked','');
 };
 
 </script>
@@ -78,7 +78,7 @@ var deselectAll = function() {
   <form action="{% url 'bulk-operation' %}" method="get">
     {% for file in files %}
     <tr class="{% cycle 'odd' 'even' %}">
-      <td><input class="file_checkbox" type="checkbox" name="file_{{file.id}}" /></td>
+      <td><input class="video_checkbox" type="checkbox" name="video_{{file.video.id}}" /></td>
       <td><a href="{{file.video.get_absolute_url}}">{{file.video.title}}</a> <a href="{{file.get_absolute_url}}">{{file.label}}</a></td>
       <td><a href="{{file.video.collection.get_absolute_url}}">{{file.video.collection.title}}</a></td>
       <td>{{file.location_type}}</td>

--- a/wardenclyffe/templates/main/file_filter.html
+++ b/wardenclyffe/templates/main/file_filter.html
@@ -75,7 +75,7 @@ var deselectAll = function() {
     </td>
   </tr>
 </form>
-  <form action="/bulk_file_operation/" method="get">
+  <form action="{% url 'bulk-operation' %}" method="get">
     {% for file in files %}
     <tr class="{% cycle 'odd' 'even' %}">
       <td><input class="file_checkbox" type="checkbox" name="file_{{file.id}}" /></td>

--- a/wardenclyffe/templates/main/file_index.html
+++ b/wardenclyffe/templates/main/file_index.html
@@ -12,10 +12,10 @@ jQuery(document).ready(function()
     } 
 ); 
 var selectAll = function()   {
-   $(".file_checkbox").attr('checked','checked');
+   $(".video_checkbox").attr('checked','checked');
 };
 var deselectAll = function() {
-   $(".file_checkbox").attr('checked','');
+   $(".video_checkbox").attr('checked','');
 };
 
 </script>
@@ -60,7 +60,7 @@ var deselectAll = function() {
 <tbody>
 {% for file in files.object_list %}
 <tr class="{% cycle 'odd' 'even' %}">
-<td><input class="file_checkbox" type="checkbox" name="file_{{file.id}}" /></td><th align="left"><a href="{{file.video.collection.get_absolute_url}}">{{file.video.collection.title}}</a>
+<td><input class="video_checkbox" type="checkbox" name="video_{{file.video.id}}" /></td><th align="left"><a href="{{file.video.collection.get_absolute_url}}">{{file.video.collection.title}}</a>
   / <a href="{{file.video.get_absolute_url}}">{{file.video.title}}</a>
   / <a href="{{file.get_absolute_url}}">{{file.label}}</a></th>
 <td><i>{{file.created|date:"M d, Y H:i:s"}}</i></td>

--- a/wardenclyffe/templates/main/file_index.html
+++ b/wardenclyffe/templates/main/file_index.html
@@ -49,7 +49,7 @@ var deselectAll = function() {
     </span>
 </div>
 
-<form action="/bulk_file_operation/" method="get">
+<form action="{% url 'bulk-operation' %}" method="get">
 <table style="width: 100%" class="tablesorter"> 
 <thead>
   <tr>

--- a/wardenclyffe/templates/main/search.html
+++ b/wardenclyffe/templates/main/search.html
@@ -31,10 +31,12 @@
 {% endif %}
 
 {% if results.videos %}
+<form action="{% url 'bulk-operation' %}" method="get">
 <h2>Videos</h2>
 <table style="width: 100%" id="recent-videos" class="tablesorter"> 
 <thead>
   <tr>
+		<th></th>
     <th colspan="2">video</th>
     <th>collection</th>
     <th>uploaded</th>
@@ -44,6 +46,7 @@
 <tbody>
 {% for video in results.videos %}
 <tr class="{% cycle 'odd' 'even' %}">
+<td><input class="video_checkbox" type="checkbox" name="video_{{video.id}}" /></td>
 <td>
 <a href="{{video.get_absolute_url}}">{% with video.poster as poster %}
 {% if poster.dummy %}
@@ -64,9 +67,24 @@
 </tbody>
 </table>
 
+<input type="button" value="select all" onclick="selectAll()"/>
+<input type="button" value="deselect all" onclick="deselectAll()"/>
+<input type="submit" value="Bulk operation on selected videos" />
+
+</form>
 {% endif %}
 
 
 {% endif %}
+
+<script type="text/javascript">
+var selectAll = function()   {
+   $(".video_checkbox").prop('checked', true);
+};
+var deselectAll = function() {
+   $(".video_checkbox").prop('checked', false);
+};
+
+</script>
 
 {% endblock %}

--- a/wardenclyffe/urls.py
+++ b/wardenclyffe/urls.py
@@ -60,7 +60,8 @@ urlpatterns = patterns(
       r'[a-z0-9]{4}-[a-z0-9]{12})/$'),
      views.OperationView.as_view()),
 
-    (r'^bulk_file_operation/$', views.BulkFileOperationView.as_view()),
+    url(r'^bulk_file_operation/$', views.BulkFileOperationView.as_view(),
+        name="bulk-operation"),
     (r'^user/(?P<username>\w+)/', views.UserView.as_view()),
     (r'^file/(?P<id>\d+)/delete/$', views.DeleteFileView.as_view()),
     (r'^file/(?P<id>\d+)/surelink/$', views.FileSurelinkView.as_view()),

--- a/wardenclyffe/urls.py
+++ b/wardenclyffe/urls.py
@@ -62,6 +62,8 @@ urlpatterns = patterns(
 
     url(r'^bulk_operation/$', views.BulkOperationView.as_view(),
         name="bulk-operation"),
+    url(r'^bulk_surelink/$', views.BulkSurelinkView.as_view(),
+        name="bulk-surelink"),
     (r'^user/(?P<username>\w+)/', views.UserView.as_view()),
     (r'^file/(?P<id>\d+)/delete/$', views.DeleteFileView.as_view()),
     (r'^file/(?P<id>\d+)/surelink/$', views.FileSurelinkView.as_view()),

--- a/wardenclyffe/urls.py
+++ b/wardenclyffe/urls.py
@@ -60,7 +60,7 @@ urlpatterns = patterns(
       r'[a-z0-9]{4}-[a-z0-9]{12})/$'),
      views.OperationView.as_view()),
 
-    url(r'^bulk_file_operation/$', views.BulkFileOperationView.as_view(),
+    url(r'^bulk_operation/$', views.BulkOperationView.as_view(),
         name="bulk-operation"),
     (r'^user/(?P<username>\w+)/', views.UserView.as_view()),
     (r'^file/(?P<id>\d+)/delete/$', views.DeleteFileView.as_view()),


### PR DESCRIPTION
Once upon a time, we implemented a bulk operation interface for Wardenclyffe. I think the only time we ever actually used it was when Brian and I needed to pull 10,000 quicktime videos down from cunix and run them all through a special PCP workflow designed to fix an encoding bug. After that it was forgotten about and more or less disappeared from the UI.

Now we'd like to bring it back and make it a little more useful. We still need to really get the video team to help us understand what use cases actually exist, but to start with, we believe that they sometimes need to run a group of videos through another PCP workflow and they also sometimes need to get surelink embed codes for a whole batch of videos all at once.

So, first I updated the bulk submit to PCP part, then I switched the bulk operation's focus from Files to Videos. Then I made it so once the user has the list of videos, they choose between submitting them all to a workflow, or getting surelink codes for them (and we can extend this with other actions once we've identified what the video team needs to be able to do).

The search results page now lets you select videos out of the results and perform a bulk operation on them. We'll want to make a more powerful filtering interface in the future (again, reliant on the video team for input), but basically anywhere that there's a list of videos in WC we want to be able to make bulk operations out of them.

The bulk surelink interface is mostly a placeholder at the moment, without the various options (it just defaults to secure versions). It's a tricky problem since we're starting with a list of videos and the availability of many of the options depends on what the underlying capabilities of the videos are, so we have to work out what to do when, eg, some of the selected videos aren't compatible with some of the selected options... For now, we just want to demonstrate that this is the kind of thing that WC can actually do.