### PR TITLE
audio mp3 -> mp4 conversion. PMT #97710

### DIFF
--- a/wardenclyffe/main/tests/test_models.py
+++ b/wardenclyffe/main/tests/test_models.py
@@ -423,6 +423,14 @@ class OperationTest(TestCase):
         for (o, p) in zip(ops, params):
             o.process(params)
 
+    def test_audio_default_operations_creation_no_encode(self):
+        f = SourceFileFactory()
+        u = UserFactory()
+        (ops, params) = f.video.make_default_operations(
+            "/tmp/file.mov",
+            f, u, True, audio_flag=False)
+        self.assertEquals(len(ops), 0)
+
     def test_submit_to_pcp_operation(self):
         f = SourceFileFactory()
         u = UserFactory()


### PR DESCRIPTION
This changes the workflow for mediathread uploaded audio files to have them encoded locally,
then sent up to S3 and Elastic Transcoder as video files. This completely eliminates
Podcast Producer from Wardenclyffe.

This feature is behind a feature flag called 'encode_audio', which is currently turned off
in production. Once this code is deployed, we can turn that flag on for testing, verify that
the pipeline all works, then turn the flag on for the general public and start working on
removing the PCP specific code from Wardenclyffe.