### PR TITLE
add smoketest to check for ffmpeg vs avconv

### DIFF
--- a/wardenclyffe/main/smoke.py
+++ b/wardenclyffe/main/smoke.py
@@ -3,6 +3,7 @@ from smoketest import SmokeTest
 from models import Collection
 from django.conf import settings
 import os.path
+import subprocess
 
 
 class DBConnectivityTest(SmokeTest):
@@ -98,3 +99,31 @@ class WatchDirTest(SmokeTest):
     def test_watchdir(self):
         self.assertTrue(os.path.exists(settings.WATCH_DIRECTORY))
         self.assertTrue(os.path.isdir(settings.WATCH_DIRECTORY))
+
+
+class FFMPEGTest(SmokeTest):
+    def test_existence(self):
+        self.assertTrue(os.path.exists(settings.FFMPEG_PATH))
+        self.assertTrue(os.path.isfile(settings.FFMPEG_PATH))
+
+    def test_notavconv(self):
+        """ the audio conversion step relies on the ffmpeg
+        binary being the *real* ffmpeg, not avconv's
+        "compatible" version.
+
+        We test by running 'ffmpeg -version' and looking at the output.
+
+        avconv's output will contain the string:
+
+            Copyright (c) 2000-2014 the Libav developers
+
+        while ffmpeg's has either:
+
+            Copyright (c) 2000-2015 the FFmpeg developers
+
+        (on 2.6+) or no copyright string on older versions.
+        """
+        output = subprocess.Popen(
+            [settings.FFMPEG_PATH, "-version"],
+            stdout=subprocess.PIPE).communicate()[0]
+        self.assertFalse("the Libav developers" in output)

--- a/wardenclyffe/settings_staging.py
+++ b/wardenclyffe/settings_staging.py
@@ -34,6 +34,8 @@ DATABASES = {
 STAGING = True
 STATSD_PREFIX = 'wardenclyffe-staging'
 
+FFMPEG_PATH = "/usr/local/bin/ffmpeg"
+
 if 'migrate' not in sys.argv:
     INSTALLED_APPS.append('raven.contrib.django.raven_compat')
 


### PR DESCRIPTION
The mp3 to mp4 encoding only works with the real ffmpeg, not avconv's fake version.

This adds a smoketest to make sure that whatever the FFMPEG_PATH setting
points at is the real deal.

The avconv version gives output like:

    $ /usr/bin/ffmpeg -version
    ffmpeg version 0.8.17-4:0.8.17-0ubuntu0.12.04.1, Copyright (c) 2000-2014 the Libav developers
      built on Mar 16 2015 13:26:50 with gcc 4.6.3
    The ffmpeg program is only provided for script compatibility and will be removed
    in a future release. It has been deprecated in the Libav project to allow for
    incompatible command line syntax improvements in its replacement called avconv
    (see Changelog for details). Please use avconv instead.
    ffmpeg 0.8.17-4:0.8.17-0ubuntu0.12.04.1
    libavutil    51. 22. 3 / 51. 22. 3
    libavcodec   53. 35. 0 / 53. 35. 0
    libavformat  53. 21. 1 / 53. 21. 1
    libavdevice  53.  2. 0 / 53.  2. 0
    libavfilter   2. 15. 0 /  2. 15. 0
    libswscale    2.  1. 0 /  2.  1. 0
    libpostproc  52.  0. 0 / 52.  0. 0

while the real ffmpeg gives output like:

    $ ffmpeg -version
    ffmpeg version 2.6.3-   http://johnvansickle.com/ffmpeg/    Copyright (c) 2000-2015 the FFmpeg developers
    built with gcc 4.9.2 (Debian 4.9.2-16)
    configuration: --enable-gpl --enable-version3 --disable-shared --disable-debug --enable-runtime-cpudetect --enable-libmp3lame --enable-libx264 --enable-libx265 --enable-libwebp --enable-libspeex --enable-libvorbis --enable-libvpx --enable-libfreetype --enable-fontconfig --enable-libxvid --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libtheora --enable-libvo-aacenc --enable-libvo-amrwbenc --enable-gray --enable-libopenjpeg --enable-libopus --enable-libass --enable-gnutls --enable-libvidstab --enable-libsoxr --cc=gcc-4.9
    libavutil      54. 20.100 / 54. 20.100
    libavcodec     56. 26.100 / 56. 26.100
    libavformat    56. 25.101 / 56. 25.101
    libavdevice    56.  4.100 / 56.  4.100
    libavfilter     5. 11.102 /  5. 11.102
    libswscale      3.  1.101 /  3.  1.101
    libswresample   1.  1.100 /  1.  1.100
    libpostproc    53.  3.100 / 53.  3.100