### PR TITLE
Images to s3

### DIFF
--- a/wardenclyffe/main/management/commands/copy_images_to_s3.py
+++ b/wardenclyffe/main/management/commands/copy_images_to_s3.py
@@ -1,0 +1,17 @@
+from django.core.management.base import BaseCommand
+from django.conf import settings
+from wardenclyffe.main.models import Image
+from wardenclyffe.main.tasks import copy_image_to_s3
+
+
+class Command(BaseCommand):
+    args = ''
+    help = ''
+
+    def handle(self, *args, **kwargs):
+        for i in Image.objects.all():
+            # sorl image.path gives the fullpath like:
+            # /var/www/wardenclyffe/uploads/images/00011/00000003.jpg
+            # so we need to get it relative to the MEDIA_ROOT
+            relpath = i.image.path[len(settings.MEDIA_ROOT):]
+            copy_image_to_s3.delay(relpath)

--- a/wardenclyffe/settings_production.py
+++ b/wardenclyffe/settings_production.py
@@ -33,6 +33,8 @@ DATABASES = {
 
 FFMPEG_PATH = "/usr/local/bin/ffmpeg"
 
+IMAGES_BUCKET = "ccnmtl-wardenclyffe-images-prod"
+
 if 'migrate' not in sys.argv:
     INSTALLED_APPS.append('raven.contrib.django.raven_compat')
 

--- a/wardenclyffe/settings_shared.py
+++ b/wardenclyffe/settings_shared.py
@@ -240,6 +240,8 @@ AUDIO_POSTER_IMAGE = os.path.join(
 COMPRESS_URL = "/media/"
 COMPRESS_ROOT = "media/"
 
+IMAGES_BUCKET = "ccnmtl-wardenclyffe-images-dev"
+
 SOUTH_MIGRATION_MODULES = {
     'taggit': 'taggit.south_migrations',
 }

--- a/wardenclyffe/settings_staging.py
+++ b/wardenclyffe/settings_staging.py
@@ -36,6 +36,8 @@ STATSD_PREFIX = 'wardenclyffe-staging'
 
 FFMPEG_PATH = "/usr/local/bin/ffmpeg"
 
+IMAGES_BUCKET = "ccnmtl-wardenclyffe-images-stage"
+
 if 'migrate' not in sys.argv:
     INSTALLED_APPS.append('raven.contrib.django.raven_compat')
 


### PR DESCRIPTION
First step of the process for moving poster/thumb images off of local disk and handing it all off to AWS. The amount of local disk space required for just holding thumbnails makes WC difficult to run on eg a smallish linode server. S3 is set up better to serve static files like this anyway. Going to S3 also lets us remove one more instance of  sorl.thumbnail.

This PR takes the first small steps:

* when images are created, it uploads a copy of each to S3 in the background, with the same relative path that we were storing it under locally.
* batch upload command to handle uploading all the existing images (I'll run this manually once this code makes it out).

Once these are in place and the batch command has been run, all existing images will have their counterparts on S3 and all new ones will get put up there as well. Then it will be safe to point at the S3 versions instead of the local ones. Once we have Elastic Transcoder outputting posters directly to S3, we will be able to just stop generating them locally.