### PR TITLE
display images from S3 instead of local/sorl

### DIFF
--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -778,14 +778,19 @@ class Image(TimeStampedModel):
     class Meta:
         order_with_respect_to = "video"
 
+    def src(self):
+        return (
+            "https://s3.amazonaws.com/"
+            + settings.IMAGES_BUCKET + "/"
+            + str(self.image))
+
 
 class Poster(models.Model):
     video = models.ForeignKey(Video)
     image = models.ForeignKey(Image)
 
     def url(self):
-        return (settings.POSTER_BASE_URL
-                + str(self.image.image))
+        return self.image.src()
 
 
 class DummyPoster:

--- a/wardenclyffe/templates/404.html
+++ b/wardenclyffe/templates/404.html
@@ -8,9 +8,6 @@
 {% endcomment %}
 
 
-{% load markup %}
-{% load thumbnail %}
-
 {% block title %}Page Not Found{% endblock %}
 
 {% block usernav %}

--- a/wardenclyffe/templates/500.html
+++ b/wardenclyffe/templates/500.html
@@ -8,9 +8,6 @@
 {% endcomment %}
 
 
-{% load markup %}
-{% load thumbnail %}
-
 {% block title %}Internal Server Error{% endblock %}
 
 {% block usernav %}

--- a/wardenclyffe/templates/main/bulk_operation.html
+++ b/wardenclyffe/templates/main/bulk_operation.html
@@ -1,6 +1,5 @@
 {% extends 'base.html' %}
 {% load markup %}
-{% load thumbnail %}
 
 {% block content %}
 
@@ -32,8 +31,7 @@
 <img src="http://ccnmtl.columbia.edu/broadcast/posters/vidthumb_480x360.jpg"
      width="160" height="120" />
 {% else %}
-{% thumbnail poster.image "160x120" as thmb %}
-<img src="{{thmb.absolute_url}}" />
+<img src="{{poster.image.src}}" width="160" />
 {% endif %}
 {% endwith %}</a>
 </td>

--- a/wardenclyffe/templates/main/bulk_surelink.html
+++ b/wardenclyffe/templates/main/bulk_surelink.html
@@ -1,5 +1,4 @@
 {% extends 'base.html' %}
-{% load thumbnail %}
 
 {% block js %}
   {% include 'main/jquery.html' %}
@@ -44,8 +43,7 @@
 <img src="http://ccnmtl.columbia.edu/broadcast/posters/vidthumb_480x360.jpg"
      width="160" height="120" />
 {% else %}
-{% thumbnail poster.image "160x120" as thmb %}
-<img src="{{thmb.absolute_url}}" />
+<img src="{{poster.image.src}}" width="160" />
 {% endif %}
 {% endwith %}</a>
 </td>

--- a/wardenclyffe/templates/main/collection.html
+++ b/wardenclyffe/templates/main/collection.html
@@ -1,6 +1,5 @@
 {% extends 'base.html' %}
 {% load markup %}
-{% load thumbnail %}
 
 {% block js %}
 {{block.super}}
@@ -99,8 +98,7 @@ jQuery(document).ready(function()
 <img src="http://ccnmtl.columbia.edu/broadcast/posters/vidthumb_480x360.jpg"
      width="160" height="120" />
 {% else %}
-{% thumbnail poster.image "160x120" as thmb %}
-<img src="{{thmb.absolute_url}}" />
+<img src="{{poster.image.src}}" width="160"/>
 {% endif %}
 {% endwith %}</a>
 </td>

--- a/wardenclyffe/templates/main/dashboard.html
+++ b/wardenclyffe/templates/main/dashboard.html
@@ -1,6 +1,5 @@
 {% extends 'base.html' %}
 {% load markup %}
-{% load thumbnail %}
 {% block title %}Dashboard{% endblock %}
 {% block pagetitle %}Dashboard{% endblock %}
 

--- a/wardenclyffe/templates/main/file.html
+++ b/wardenclyffe/templates/main/file.html
@@ -1,4 +1,6 @@
 {% extends 'base.html' %}
+{% load markup %}
+{% load oembed_tags %}
 
 {% block js %}
   {% include 'main/jquery.html' %}
@@ -17,9 +19,6 @@
 
 {% endblock %}
 
-{% load markup %}
-{% load thumbnail %}
-{% load oembed_tags %}
 {% block content %}
 <p><a href="{{file.video.collection.get_absolute_url}}">{{file.video.collection.title}}</a>/<a href="{{file.video.get_absolute_url}}">{{file.video.title}}</a></p>
 <h1>File: {{file.label}}</h1>

--- a/wardenclyffe/templates/main/index.html
+++ b/wardenclyffe/templates/main/index.html
@@ -1,6 +1,5 @@
 {% extends 'base.html' %}
 {% load markup %}
-{% load thumbnail %}
 {% block title %}Dashboard{% endblock %}
 {% block pagetitle %}Dashboard{% endblock %}
 {% block js %}
@@ -37,7 +36,7 @@ jQuery(function($){
     <div class="table-header">
 		<div class="table_title">Recent videos and operations</div><!-- class="table_title" -->
 		<div class="add_new"><a href="/upload/">add video</a></div><!-- class="add_new" -->
-	</div><!--  class="table-header -->
+	</div><!--  class="table-header" -->
 	
 	{% if videos %}
 	<table>
@@ -69,8 +68,7 @@ jQuery(function($){
 						<img src="{{STATIC_URL}}img/vidthumb160.jpg" width="160" height="120" />
             {% endif %}
 						{% else %}
-						{% thumbnail poster.image.image "160x120" as thmb %}
-						<img src="{{thmb.absolute_url}}" width="160"/>
+						<img src="{{poster.image.src}}" width="160"/>
 						{% endif %}
 						{% endwith %}</a>
 						</div><!-- class="video_thumbnail" -->

--- a/wardenclyffe/templates/main/search.html
+++ b/wardenclyffe/templates/main/search.html
@@ -1,5 +1,4 @@
 {% extends 'base.html' %}
-{% load thumbnail %}
 
 {% block content %}
 
@@ -53,8 +52,7 @@
 <img src="http://ccnmtl.columbia.edu/broadcast/posters/vidthumb_480x360.jpg"
      width="160" height="120" />
 {% else %}
-{% thumbnail poster.image "160x120" as thmb %}
-<img src="{{thmb.absolute_url}}" />
+<img src="{{poster.image.src}}" width="160" />
 {% endif %}
 {% endwith %}</a>
 </td>

--- a/wardenclyffe/templates/main/slow_operations.html
+++ b/wardenclyffe/templates/main/slow_operations.html
@@ -1,6 +1,5 @@
 {% extends 'base.html' %}
 {% load markup %}
-{% load thumbnail %}
 {% block title %}Slow Operations{% endblock %}
 {% block pagetitle %}Slow Operations{% endblock %}
 

--- a/wardenclyffe/templates/main/uuid_search.html
+++ b/wardenclyffe/templates/main/uuid_search.html
@@ -1,5 +1,4 @@
 {% extends 'base.html' %}
-{% load thumbnail %}
 
 {% block content %}
 

--- a/wardenclyffe/templates/main/video.html
+++ b/wardenclyffe/templates/main/video.html
@@ -1,7 +1,6 @@
 {% extends 'base.html' %}
 {% load waffle_tags %}
 {% load markup %}
-{% load thumbnail %}
 {% load oembed_tags %}
 
 {% block js %}
@@ -48,8 +47,7 @@ var removeTag = function(tagName,tagId) {
 <img src="http://ccnmtl.columbia.edu/broadcast/posters/vidthumb_480x360.jpg"
      />
 {% else %}
-{% thumbnail poster.image "480x360" as thmb %}
-<img src="{{thmb.absolute_url}}" />
+<img src="{{poster.image.src}}" width="480" />
 {% endif %}
 {% endwith %}
 </td>
@@ -86,8 +84,8 @@ var removeTag = function(tagName,tagId) {
 <div id="frames">
 {% if video.image_set.count %}
 {% for image in video.upto_hundred_images %}
-{% thumbnail image.image "200x200" as thmb %}
-<div style="float: left; width: 200px"><img src="{{thmb.absolute_url}}" /><br />
+<div style="float: left; width: 200px"><img src="{{image.src}}"
+																						width="200" /><br />
 <a href="select_poster/{{image.id}}/">make poster</a></div>
 {% endfor %}
 <br style="clear:both" />


### PR DESCRIPTION
Images are now all up on S3 in addition to local.

This cuts over all the images that appear in the WC web UI to use the S3 version instead of the local/sorl version.

A downside to this is that on pages where sorl was actually thumbnailing the image, we're now just loading the full-size and letting the browser scale it. That's not ideal, wasting some bandwidth and client-side CPU/memory, but since there aren't that many users hitting those parts of WC directly (just our video team), I think it's an acceptable tradeoff, at least for the time being. We can do some pre-scaling if it becomes an issue, but we might as well wait until we're entirely cut over to S3 to do that.