### PR TITLE
tell elastic transcoder to generate thumbnails

### DIFF
--- a/wardenclyffe/main/tasks.py
+++ b/wardenclyffe/main/tasks.py
@@ -91,6 +91,9 @@ def create_elastic_transcoder_job(operation, params):
             'PresetId': settings.AWS_ET_MP4_PRESET,
         }
     ]
+    if waffle.switch_is_active('enable_et_thumbs'):
+        output_objects[0]['ThumbnailPattern'] = (
+            "thumbs/" + output_base + "-{count}")
     if waffle.switch_is_active('enable_720p'):
         output_objects.append(
             {

--- a/wardenclyffe/main/views.py
+++ b/wardenclyffe/main/views.py
@@ -1376,6 +1376,11 @@ class SNSView(View):
             operation.save()
             tf[0].delete()
 
+            # log the full response so I can look at it
+            # and figure out what format they are going to
+            # use to give us the paths for thumbs
+            operation.log(full_message)
+
             if waffle.flag_is_active(request, 's3_to_cunix'):
                 # add S3 output file record
                 for output in ets_message['outputs']:


### PR DESCRIPTION
This whole area of elastic transcoder is not well documented, so this is a bit of a shot in the dark. So it's behind a waffle flag.

The pipeline is set up with the right output S3 bucket and the preset has settings for  thumbnail generation.

I *think* the way to trigger it to actually generate thumbs is by specifying the `ThumbnailPattern` with `{count}` somewhere in it. I haven't been able to find a single full example anywhere online though, so it's still a bit of a guess.

The documentation on the SNS notification format that they send back when the encoding is done (http://docs.aws.amazon.com/elastictranscoder/latest/developerguide/notifications.html) also conveniently leaves out thumbnails. So it's also not obvious how we get information on what thumbs it actually created. So I'm logging the full SNS message so I can inspect that and figure it out by running a few through.