### PR TITLE
ET thumbs output

### DIFF
--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -309,6 +309,10 @@ class Video(TimeStampedModel):
         params = dict(file_id=file_id)
         return self.make_op(user, params, action="copy from s3 to cunix")
 
+    def make_pull_thumbs_from_s3_operation(self, pattern, user):
+        params = dict(pattern=pattern)
+        return self.make_op(user, params, action="pull thumbs from s3")
+
     def make_audio_encode_operation(self, file_id, user):
         """ pull the file down from S3
         run it through the audio encode job
@@ -706,6 +710,8 @@ class Operation(TimeStampedModel):
             wardenclyffe.main.tasks.audio_encode,
             "local audio encode":
             wardenclyffe.main.tasks.local_audio_encode,
+            "pull thumbs from s3":
+            wardenclyffe.main.tasks.pull_thumbs_from_s3,
         }
         return mapper[self.action]
 

--- a/wardenclyffe/main/tests/thumbnail_pattern.json
+++ b/wardenclyffe/main/tests/thumbnail_pattern.json
@@ -1,0 +1,12 @@
+{
+		"SignatureVersion": "1",
+		"Timestamp": "2015-05-29T14:40:31.611Z",
+		"Signature": "eJ2Do1qbkStOfP/Y3eCyHyNkHs+AuSELbc96rsNQ+Q4VR8bbACtLAdEU6evbnqeDOsY8y36XVq2HwoqdvHwTyGrhfu0nymyxdcA6zmQDfHp5fa7UArveXTqbvAEtSJC3q5niRnVYggZyGEL4eRK2Al2KajLnkY2+eFb3P6+vNN99SVSC0HCZwdU6yWXGTqx5k+yeHQgt2Q8nTR4kVW4FSz8bWYqLbr5QZ0IYpZbbzEJrC2jmnVM0Co9LKxvtHOXWut69TDCQAFC3x8ETsrt6Jk9qN94QmBmMaHYGaGtLBqtWN/pdSUvUKi7OaCbHb/plNvn3qPlvQ1NzmzAyPYhgMA==",
+		"SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-d6d679a1d18e95c2f9ffcf11f4f9e198.pem",
+		"MessageId": "72354795-1d8a-5c7d-b984-0a7761152144",
+		"Message": "{\n \"state\" : \"COMPLETED\",\n \"version\" : \"2012-09-25\",\n \"jobId\" : \"1432910411000-tfe2a2\",\n \"pipelineId\" : \"1411726625254-3hgwum\",\n \"input\" : {\n \"key\" : \"2015/05/29/f39f7a39-0fb7-4d78-8a17-f6fb92845770.mp4\",\n \"frameRate\" : \"auto\",\n \"resolution\" : \"auto\",\n \"interlaced\" : \"auto\"\n },\n \"outputs\" : [ {\n \"id\" : \"1\",\n \"presetId\" : \"1432897202697-8e0zgo\",\n \"key\" : \"2015/05/29/e573cfeb-e32c-45c0-8caa-326c394b04b9_480.mp4\",\n \"thumbnailPattern\" : \"thumbs/2015/05/29/e573cfeb-e32c-45c0-8caa-326c394b04b9-{count}\",\n \"rotate\" : \"auto\",\n \"status\" : \"Complete\",\n \"duration\" : 71,\n \"width\" : 640,\n \"height\" : 360\n } ]\n}",
+		"UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:051882422638:ccnmtl-wardenclyffe-sns-prod:de64c5c9-0a0c-46a7-9aa3-80d13746005f",
+		"Type": "Notification",
+		"TopicArn": "arn:aws:sns:us-east-1:051882422638:ccnmtl-wardenclyffe-sns-prod",
+		"Subject": "Amazon Elastic Transcoder has finished transcoding job 1432910411000-tfe2a2."
+}

--- a/wardenclyffe/main/views.py
+++ b/wardenclyffe/main/views.py
@@ -1393,6 +1393,10 @@ class SNSView(View):
                     label=label)
                 OperationFile.objects.create(operation=operation, file=f)
                 v = operation.video
+                if 'thumbnailPattern' in output:
+                    (o, p) = v.make_pull_thumbs_from_s3_operation(
+                        output['thumbnailPattern'], operation.owner)
+                    operations.append((o, p))
                 (o, p) = v.make_copy_from_s3_to_cunix_operation(
                     f.id, operation.owner)
                 operations.append((o, p))

--- a/wardenclyffe/main/views.py
+++ b/wardenclyffe/main/views.py
@@ -36,7 +36,6 @@ from surelink.helpers import AUTHTYPE_OPTIONS
 from surelink import SureLink
 from wardenclyffe.util import uuidparse
 from wardenclyffe.util.mail import send_mediathread_received_mail
-import waffle
 
 
 def is_staff(user):
@@ -1381,23 +1380,22 @@ class SNSView(View):
             # use to give us the paths for thumbs
             operation.log(full_message)
 
-            if waffle.flag_is_active(request, 's3_to_cunix'):
-                # add S3 output file record
-                for output in ets_message['outputs']:
-                    label = "transcoded 480p file (S3)"
-                    if output['presetId'] == settings.AWS_ET_720_PRESET:
-                        label = "transcoded 720p file (S3)"
-                    f = File.objects.create(
-                        video=operation.video,
-                        cap=output['key'],
-                        location_type="s3",
-                        filename=output['key'],
-                        label=label)
-                    OperationFile.objects.create(operation=operation, file=f)
-                    v = operation.video
-                    (o, p) = v.make_copy_from_s3_to_cunix_operation(
-                        f.id, operation.owner)
-                    operations.append((o, p))
+            # add S3 output file record
+            for output in ets_message['outputs']:
+                label = "transcoded 480p file (S3)"
+                if output['presetId'] == settings.AWS_ET_720_PRESET:
+                    label = "transcoded 720p file (S3)"
+                f = File.objects.create(
+                    video=operation.video,
+                    cap=output['key'],
+                    location_type="s3",
+                    filename=output['key'],
+                    label=label)
+                OperationFile.objects.create(operation=operation, file=f)
+                v = operation.video
+                (o, p) = v.make_copy_from_s3_to_cunix_operation(
+                    f.id, operation.owner)
+                operations.append((o, p))
         else:
             # set it to failed
             operation.status = "failed"


### PR DESCRIPTION
Videos transcoded by ET now also produce thumbs.

ET notifies us about them by putting a `thumbnailPattern` entry into the SNS notification it sends when the job completes.

That pattern is basically the one that we submitted when we created the job, so now we're left to search the images bucket to see how many it actually created and make the corresponding database entries for them.