### PR TITLE
pull video down from s3 to extract metadata

### DIFF
--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -287,6 +287,10 @@ class Video(TimeStampedModel):
                       source_file_id=source_file.id)
         return self.make_op(user, params, action="extract metadata")
 
+    def make_pull_from_s3_and_extract_metadata_operation(self, key, user):
+        return self.make_op(user, dict(key=key),
+                            action="pull from s3 and extract metadata")
+
     def make_save_file_to_s3_operation(self, tmpfilename, user):
         params = dict(tmpfilename=tmpfilename, filename=tmpfilename)
         return self.make_op(user, params, action="save file to S3")
@@ -372,11 +376,6 @@ class Video(TimeStampedModel):
                 operations.append(o)
                 params.append(p)
         else:
-            o, p = self.make_extract_metadata_operation(
-                tmpfilename, source_file, user)
-            operations.append(o)
-            params.append(p)
-
             o, p = self.make_save_file_to_s3_operation(
                 tmpfilename, user)
             operations.append(o)
@@ -690,6 +689,8 @@ class Operation(TimeStampedModel):
 
         mapper = {
             'extract metadata': wardenclyffe.main.tasks.extract_metadata,
+            'pull from s3 and extract metadata':
+            wardenclyffe.main.tasks.extract_metadata,
             'save file to S3': wardenclyffe.main.tasks.save_file_to_s3,
             'make images': wardenclyffe.main.tasks.make_images,
             'import from cuit': wardenclyffe.cuit.tasks.import_from_cuit,

--- a/wardenclyffe/main/tasks.py
+++ b/wardenclyffe/main/tasks.py
@@ -61,6 +61,9 @@ def save_file_to_s3(operation, params):
                             label="uploaded source file (S3)")
     OperationFile.objects.create(operation=operation, file=f)
 
+    o, p = operation.video.make_pull_from_s3_and_extract_metadata_operation(
+        key=key, user=operation.owner)
+    process_operation.delay(o.id, p)
     o, p = operation.video.make_create_elastic_transcoder_job_operation(
         key=key, user=operation.owner)
     process_operation.delay(o.id, p)
@@ -273,18 +276,34 @@ def midentify_path():
     return os.path.join(script_dir, "midentify.sh")
 
 
+def pull_from_s3_and_extract_metadata(operation, params):
+    statsd.incr("pull_from_s3_and_extract_metadata")
+    print "pulling from S3"
+    video = operation.video
+    suffix = video.extension()
+    t = pull_from_s3(suffix, settings.AWS_S3_UPLOAD_BUCKET,
+                     params['key'])
+    do_extract_metadata(video.source_file(), t.name)
+    # clean up
+    t.close()
+    return ("complete", "")
+
+
 def extract_metadata(operation, params):
-    statsd.incr("extract_metadata")
     source_file = File.objects.get(id=params['source_file_id'])
+    do_extract_metadata(source_file, params['tmpfilename'])
+    return ("complete", "")
+
+
+def do_extract_metadata(source_file, filename):
+    statsd.incr("extract_metadata")
     output = unicode(
         subprocess.Popen(
-            [midentify_path(),
-             params['tmpfilename']],
+            [midentify_path(), filename],
             stdout=subprocess.PIPE).communicate()[0],
         errors='replace')
     for f, v in parse_metadata(output):
         source_file.set_metadata(f, v)
-    return ("complete", "")
 
 
 def parse_metadata(output):
@@ -354,6 +373,7 @@ def pull_from_s3_and_submit_to_pcp(operation, params):
     print "submitting to PCP"
     filename = str(ouuid) + suffix
     pcp_upload(filename, t, ouuid, operation, workflow, video.description)
+    t.close()
     return ("submitted", "submitted to PCP")
 
 

--- a/wardenclyffe/main/tests/test_models.py
+++ b/wardenclyffe/main/tests/test_models.py
@@ -406,7 +406,7 @@ class OperationTest(TestCase):
         (ops, params) = f.video.make_default_operations(
             "/tmp/file.mov",
             f, u)
-        self.assertEquals(len(ops), 2)
+        self.assertEquals(len(ops), 1)
         # just run these to get the coverage up. don't worry if they fail
         for (o, p) in zip(ops, params):
             o.process(params)

--- a/wardenclyffe/main/tests/test_models.py
+++ b/wardenclyffe/main/tests/test_models.py
@@ -406,7 +406,7 @@ class OperationTest(TestCase):
         (ops, params) = f.video.make_default_operations(
             "/tmp/file.mov",
             f, u)
-        self.assertEquals(len(ops), 3)
+        self.assertEquals(len(ops), 2)
         # just run these to get the coverage up. don't worry if they fail
         for (o, p) in zip(ops, params):
             o.process(params)


### PR DESCRIPTION
Working on decoupling WC tasks from the uploaded video file that's sitting
in the temp dir. It's more work to have each task pull the file down
from S3, do it's thing and then delete the temp file, but it lets us
separate the webserver from the celery worker and sets us up to
have users upload their files directly to S3 instead of going through
WC's webserver.

Here, basically, instead of kicking off the extract metadata job immediately on upload, using the temp file, we wait until the file has been saved to S3, then we trigger a version that pulls it back down from S3, does its work and deletes it.

Note that since this one and #92 both decrease the expected number of default tasks, there will be a conflict and/or test failure on line 409 of `wardenclyffe/main/tests/test_models.py` on whichever of these gets merged second. To fix, you'll just need to decrease the expected number by one.