### PR TITLE
:bug: if the video is uploaded to the public collection, put it in the public directory. PMT #97823

### DIFF
--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -58,6 +58,12 @@ class Collection(TimeStampedModel):
                 exclude = ('collection', )
         return AddVideoForm()
 
+    def is_public(self):
+        """ is this the h264 Public collection? """
+        # TODO: make this a user-editable attribute
+        # rather than having it hard-coded here.
+        return self.title == "h264 Public"
+
 
 class CollectionWorkflow(models.Model):
     collection = models.ForeignKey(Collection)

--- a/wardenclyffe/main/tasks.py
+++ b/wardenclyffe/main/tasks.py
@@ -443,12 +443,15 @@ def sftp_client():
     return (paramiko.SFTPClient.from_transport(transport), transport)
 
 
-def sftp_put(filename, suffix, fileobj, video, file_label="CUIT H264"):
+def sftp_put(filename, suffix, fileobj, video, file_label="CUIT H264",
+             remote_path=None):
     sftp, transport = sftp_client()
     remote_filename = filename.replace(suffix, "_et" + suffix)
-    remote_path = os.path.join(
-        settings.CUNIX_H264_DIRECTORY, "ccnmtl", "secure",
-        remote_filename)
+    if remote_path is None:
+        # default to secure directory if not otherwise specified
+        remote_path = os.path.join(
+            settings.CUNIX_H264_DIRECTORY, "ccnmtl", "secure",
+            remote_filename)
 
     try:
         sftp.putfo(fileobj, remote_path)


### PR DESCRIPTION
Specifically, when it comes back from ET, we need to check if it's in the
public collection, and if so, upload it to the public directory
on the CUIT media server.

For now, it's basically hard-coded as to which collection is public
(defaulting to secure for anything else). In lieu of a more comprehensive
approach to configuring where things end up, this will have to do.