### PR TITLE
stop using sorl entirely

### DIFF
--- a/wardenclyffe/main/migrations/0002_auto_20150604_0617.py
+++ b/wardenclyffe/main/migrations/0002_auto_20150604_0617.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='image',
+            name='image',
+            field=models.CharField(max_length=100),
+            preserve_default=True,
+        ),
+    ]

--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -2,7 +2,6 @@ from django.db import models
 from django_extensions.db.fields import UUIDField
 from django_extensions.db.models import TimeStampedModel
 from django.contrib.auth.models import User
-from sorl.thumbnail.fields import ImageWithThumbnailsField
 from django import forms
 from taggit.managers import TaggableManager
 from surelink import SureLink
@@ -771,8 +770,7 @@ class OperationLog(TimeStampedModel):
 
 class Image(TimeStampedModel):
     video = models.ForeignKey(Video)
-    image = ImageWithThumbnailsField(upload_to="images",
-                                     thumbnail={'size': (100, 100)})
+    image = models.CharField(max_length=100)
 
     class Meta:
         order_with_respect_to = "video"

--- a/wardenclyffe/settings_shared.py
+++ b/wardenclyffe/settings_shared.py
@@ -110,7 +110,6 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'compressor',
-    'sorl.thumbnail',
     'django.contrib.admin',
     'tagging',
     'smartif',


### PR DESCRIPTION
`CharField(max_length=100)` is apparently equivalent to what sorl was using under the hood to store the image path. So this migration has the nice property of eliminating the `sorl` specific field without actually making any changes to the database. Once this has gone through, we can think about making that field something more appropriate.

Note that sorl is still listed in `requirements.txt`, since earlier migration scripts still need to be able to import it, even if we are no longer using it. In the future we can go through and carefully excise mention of sorl from those migrations and fully remove it from the project.