### PR TITLE
collectstatic fix

### DIFF
--- a/wardenclyffe/settings_shared.py
+++ b/wardenclyffe/settings_shared.py
@@ -220,8 +220,8 @@ DEFAULT_POSTER_URL = (
     "broadcast/posters/vidthumb_480x360.jpg")
 STAGING = False
 
-STATIC_ROOT = os.path.join(os.path.dirname(__file__), "../media")
-STATICFILES_DIRS = ()
+STATIC_ROOT = '/tmp/wardenclyffe/static'
+STATICFILES_DIRS = ('media/',)
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',


### PR DESCRIPTION
collectstatic was failing to pickup the wardenclyffe/media directory. this fix was made manually to staging & production