### PR TITLE
Uploadify hack. Fixes PMT #101551

### DIFF
--- a/wardenclyffe/templates/main/jquery.html
+++ b/wardenclyffe/templates/main/jquery.html
@@ -1,4 +1,4 @@
 <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.0/themes/smoothness/jquery-ui.css" />
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-<script src="/media/js/jquery-migrate-1.2.1.min.js"></script>
+<script src="{{STATIC_URL}}js/jquery-migrate-1.2.1.min.js"></script>
 <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.0/jquery-ui.min.js"></script>

--- a/wardenclyffe/templates/mediathread/mediathread.html
+++ b/wardenclyffe/templates/mediathread/mediathread.html
@@ -128,7 +128,7 @@
         jQuery(document).ready(function() {
           
           jQuery('#file_upload').uploadify({
-              'swf'  : '{{STATIC_URL}}swf/uploadify.swf',
+              'swf'  : '/media/swf/uploadify.swf',
               'uploader'    : '/uploadify/',
               'cancelImg' : '{{STATIC_URL}}img/pixel.gif',
               'folder'    : '/uploads',


### PR DESCRIPTION
Load the SWF locally for now.

This is a short-term patch to get stuff working again while we work on just switching over to plupload, which doesn't have this issue.