### PR TITLE
local audio encode pulls from s3. PMT #101560

### DIFF
--- a/wardenclyffe/main/tests/test_models.py
+++ b/wardenclyffe/main/tests/test_models.py
@@ -424,14 +424,6 @@ class OperationTest(TestCase):
         for o in ops:
             o.process()
 
-    def test_audio_default_operations_creation_no_encode(self):
-        f = SourceFileFactory()
-        u = UserFactory()
-        ops = f.video.make_default_operations(
-            "/tmp/file.mov",
-            f, u, True, audio_flag=False)
-        self.assertEquals(len(ops), 0)
-
     def test_submit_to_pcp_operation(self):
         f = SourceFileFactory()
         u = UserFactory()


### PR DESCRIPTION
instead of processing the mp3 file directly, locally, it now
uploads the source mp3 to S3. then the audio encode operation
works by pulling that mp3 down from s3 to process.

this sounds backwards if you haven't been paying attention to the
ongoing wardenclyffe refactoring.

the real goal here is to make all operations not have any
assumptions about what might already be sitting on the local
filesystem; always pulling from S3 instead. this frees us up
to have the celery worker(s) on different machines than the
web worker. it also sets us up to switch to having users
upload directly to S3 without ever touching the filesystem on
the web app