### PR TITLE
disable max_retries

### DIFF
--- a/wardenclyffe/main/tasks.py
+++ b/wardenclyffe/main/tasks.py
@@ -38,7 +38,7 @@ def exp_backoff(tries):
     return int(backoff + jitter)
 
 
-@task(ignore_results=True, bind=True)
+@task(ignore_results=True, bind=True, max_retries=None)
 def process_operation(self, operation_id, **kwargs):
     print "process_operation(%s)" % (operation_id)
     try:


### PR DESCRIPTION
since we're handling it ourselves with exponential backoff, we need to
tell celery not to use its default of 3 retries.