### PR TITLE
graphite metrics for retries

### DIFF
--- a/wardenclyffe/main/tasks.py
+++ b/wardenclyffe/main/tasks.py
@@ -52,7 +52,10 @@ def process_operation(self, operation_id, **kwargs):
         if self.request.retries > 10:
             # max out at 10 retry attempts
             operation.fail(str(exc))
+            statsd.incr("max_retries")
         else:
+            statsd.incr("retry_operation")
+            statsd.incr("retry_%02d" % self.request.retries)
             self.retry(exc=exc, countdown=exp_backoff(self.request.retries))
 
 


### PR DESCRIPTION
It would be nice to be able to keep track of how often tasks get
retried, now many retries happen, and whether they are maxing out.

This adds a couple metrics to graphite/statsd for that. There's one
counter that for every retry that happens, one for when max_retries is
reached, and then individual 'retry_01', 'retry_02', etc counters so we
can get a sense of how many retries it takes to get an operation to
complete. I think these will be handy to graph and alert off of.