### PR TITLE
handle simultaneous SNS responses a little better

### DIFF
--- a/wardenclyffe/main/views.py
+++ b/wardenclyffe/main/views.py
@@ -1339,14 +1339,15 @@ class SNSView(View):
             # success report for a non-existent transcoding
             # job. assume it's a duplicate
             return HttpResponse("OK")
-        operation = tf[0].operationfile_set.all()[0].operation
+        fo = tf.first()
+        operation = fo.operationfile_set.first().operation
+        fo.delete()
 
         operations = []
         if state == 'COMPLETED':
             # set it to completed
             operation.status = "complete"
             operation.save()
-            tf[0].delete()
 
             # add S3 output file record
             for output in ets_message['outputs']:
@@ -1372,7 +1373,6 @@ class SNSView(View):
             # set it to failed
             operation.status = "failed"
             operation.save()
-            tf[0].delete()
             operation.log(info=self.body)
         for o in operations:
             tasks.process_operation.delay(o.id)


### PR DESCRIPTION
This sentry error:
https://sentry.ccnmtl.columbia.edu/sentry-internal/wardenclyffe/group/911/

seems to come from amazon occasionally sending duplicate SNS events and
triggering a race condition. (this can happen on this view since it's in
non-atomic request mode).

It's not frequent and doesn't break anything, and this doesn't totally
fix the issue, but it reduces the span between checking if the specified
`File` exists and working with it, so the race condition should at least
be less common.