### PR TITLE
add a sign s3 view

### DIFF
--- a/wardenclyffe/main/tests/test_views.py
+++ b/wardenclyffe/main/tests/test_views.py
@@ -10,6 +10,7 @@ from factories import (
     UserFactory, VideoFactory, CollectionFactory,
     ImageFactory, OperationFileFactory)
 from httpretty import HTTPretty, httprettified
+import json
 import os.path
 import httpretty
 
@@ -328,6 +329,20 @@ class TestUploadify(TestCase):
         self.c = Client()
         response = self.c.post("/uploadify/", {})
         self.assertEqual(response.status_code, 200)
+
+
+class TestSignS3View(TestCase):
+    def test_sign_s3(self):
+        self.c = Client()
+        with self.settings(
+                AWS_ACCESS_KEY='',
+                AWS_SECRET_KEY='',
+                AWS_S3_UPLOAD_BUCKET=''):
+            r = self.c.get(
+                "/sign_s3/?s3_object_name=default_name&s3_object_type=foo")
+            self.assertEqual(r.status_code, 200)
+            j = json.loads(r.content)
+            self.assertTrue('signed_request' in j)
 
 
 class TestStaff(TestCase):

--- a/wardenclyffe/main/views.py
+++ b/wardenclyffe/main/views.py
@@ -1,7 +1,12 @@
 # stdlib imports
+import base64
+import hmac
 import os
 import uuid
 import requests
+import time
+import urllib
+
 import wardenclyffe.main.tasks as tasks
 
 from django.shortcuts import render
@@ -22,6 +27,7 @@ from django.views.generic.detail import DetailView
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
 from django.views.generic.list import ListView
 from django_statsd.clients import statsd
+from hashlib import sha1
 from json import dumps, loads
 from taggit.models import Tag
 from wardenclyffe.main.forms import ServerForm, EditCollectionForm
@@ -33,7 +39,7 @@ from wardenclyffe.main.models import OperationFile
 from surelink.helpers import PROTECTION_OPTIONS
 from surelink.helpers import AUTHTYPE_OPTIONS
 from surelink import SureLink
-from wardenclyffe.util import uuidparse
+from wardenclyffe.util import uuidparse, safe_basename
 from wardenclyffe.util.mail import send_mediathread_received_mail
 
 
@@ -1253,3 +1259,46 @@ class SNSView(View):
                 'Notification'):
             return self._notification(request)
         return HttpResponse("unknown message type", status=400)
+
+
+class SignS3View(View):
+    def get(self, request):
+        AWS_ACCESS_KEY = settings.AWS_ACCESS_KEY
+        AWS_SECRET_KEY = settings.AWS_SECRET_KEY
+        S3_BUCKET = settings.AWS_S3_UPLOAD_BUCKET
+
+        object_name = safe_basename(
+            request.GET.get('s3_object_name', 'unknown.obj'))
+        mime_type = request.GET.get('s3_object_type')
+        (basename, extension) = os.path.splitext(object_name)
+
+        n = datetime.now()
+        uid = str(uuid.uuid4())
+
+        object_name = "%04d/%02d/%02d/%s-%s%s" % (
+            n.year, n.month, n.day, basename, uid, extension)
+
+        expires = int(time.time()+10)
+        amz_headers = "x-amz-acl:public-read"
+
+        put_request = "PUT\n\n%s\n%d\n%s\n/%s/%s" % (
+            mime_type, expires, amz_headers, S3_BUCKET, object_name)
+
+        signature = base64.encodestring(
+            hmac.new(AWS_SECRET_KEY, put_request, sha1).digest())
+
+        signature = urllib.quote_plus(signature.strip())
+
+        # Encode the plus symbols
+        # https://pmt.ccnmtl.columbia.edu/item/95796/
+        signature = urllib.quote(signature)
+
+        url = 'https://s3.amazonaws.com/%s/%s' % (S3_BUCKET, object_name)
+        signed_request = '%s?AWSAccessKeyId=%s&Expires=%d&Signature=%s' % (
+            url, AWS_ACCESS_KEY, expires, signature)
+
+        return HttpResponse(
+            dumps({
+                'signed_request': signed_request,
+                'url': url
+            }), content_type="application/json")

--- a/wardenclyffe/urls.py
+++ b/wardenclyffe/urls.py
@@ -110,6 +110,7 @@ urlpatterns = patterns(
     (r'^stats/$', TemplateView.as_view(template_name="main/stats.html")),
     (r'^stats/auth/$',
      TemplateView.as_view(template_name="main/auth_stats.html")),
+    url(r'^sign_s3/$', views.SignS3View.as_view(), name='sign-s3'),
     (r'^uploads/(?P<path>.*)$',
      'django.views.static.serve',
      {'document_root': settings.MEDIA_ROOT}),

--- a/wardenclyffe/util/__init__.py
+++ b/wardenclyffe/util/__init__.py
@@ -1,3 +1,4 @@
+import os
 import re
 
 
@@ -18,3 +19,16 @@ def uuidparse(s):
         return m.group()
     else:
         return ""
+
+
+def safe_basename(s):
+    """ take whatever crap the browser gives us,
+    often something like "C:\fakepath\foo bar.png"
+    and turn it into something suitable for our
+    purposes"""
+    # ntpath does the best at cross-platform basename extraction
+    b = os.path.basename(s)
+    b = b.lower()
+    # only allow alphanumerics, '-' and '.'
+    b = re.sub(r'[^\w\-\.]', '', b)
+    return b

--- a/wardenclyffe/util/tests.py
+++ b/wardenclyffe/util/tests.py
@@ -1,3 +1,5 @@
+import unittest
+
 from django.core import mail
 from django.test import TestCase
 from wardenclyffe.util.mail import slow_operations_email_body
@@ -10,7 +12,7 @@ from wardenclyffe.util.mail import send_failed_operation_mail
 from wardenclyffe.util.mail import send_mediathread_received_mail
 from wardenclyffe.util.mail import send_mediathread_uploaded_mail
 from wardenclyffe.util.mail import send_youtube_submitted_mail
-from wardenclyffe.util import uuidparse
+from wardenclyffe.util import uuidparse, safe_basename
 
 
 class DummyVideo(object):
@@ -133,3 +135,8 @@ class UUIDParseTest(TestCase):
         self.assertEqual(
             uuidparse('not a uuid'),
             '')
+
+
+class SafeBasenameTests(unittest.TestCase):
+    def test_safe_basename(self):
+        self.assertEqual(safe_basename('Foo bar.png'), 'foobar.png')


### PR DESCRIPTION
this is the first phase of implementing direct to S3 upload
functionality (PMT #93962). provides an s3 upload signing view, more or
less ripped straight from the DMT.

For now, it's not actually hooked up to anything in the front-end. That
will come next.