### PR TITLE
make a source file object on s3 upload

### DIFF
--- a/wardenclyffe/main/views.py
+++ b/wardenclyffe/main/views.py
@@ -644,6 +644,10 @@ def s3upload(request):
 
     key = key_from_s3url(s3url)
 
+    # we need a source file object in there
+    # to attach basic metadata to
+    v.make_source_file(key)
+
     label = "uploaded source file (S3)"
     File.objects.create(video=v, url="", cap=key,
                         location_type="s3",


### PR DESCRIPTION
I'd taken that out of the straight to s3 workflow reasoning that we no
longer had a source file on the filesystem.

It looks like the extract metadata task still expects it to exist though
so it can stash metadata on it.

Easy enough to put it back in.

Once we've moved everything to S3 upload only, it will probably be much
simpler to just have the extract metadata job create it itself instead
of relying on it to already have been created.