### PR TITLE
remove drop-off directory functionality on s3 upload

### DIFF
--- a/wardenclyffe/templates/main/s3upload.html
+++ b/wardenclyffe/templates/main/s3upload.html
@@ -1,8 +1,8 @@
 {% extends 'base.html' %}
 {% load waffle_tags %}
 {% load compress %}
-{% block title %}{% if scan_directory %}Add Video from Drop-off Directory{% else %}Add Video from Desktop{% endif %}{% endblock %}
-{% block pagetitle %}{% if scan_directory %}Add Video from Drop-off Directory{% else %}Add Video from Desktop{% endif %}{% endblock %}
+{% block title %}Add Video from Desktop{% endblock %}
+{% block pagetitle %}Add Video from Desktop{% endblock %}
 
 {% block extra_head %}
     {% compress js %}
@@ -24,18 +24,6 @@
     <form action="/s3upload/post/" method="post" enctype="multipart/form-data">
 
         <div class="panel_top">
-	          <div class="form_video_source">
-		            <div class="form_video_source_title">Video source:</div>
-                {% if scan_directory %}
-                    <div class="wc_button inactive_button"><a href="/upload/" title="Upload files from your desktop">Desktop</a></div><!-- class="wc_button" -->
-                    <div class="wc_button active_button">Drop-off directory</div><!-- class="wc_button" -->
-                {% else %}
-		                <div class="wc_button active_button">Desktop</div><!-- class="wc_button" -->
-		                <div class="wc_button inactive_button"><a href="/scan_directory/" title="Upload files from the drop-off directory">Drop-off directory</a></div><!-- class="wc_button" -->
-                {% endif %}
-		            <div class="wc_help_button" id="help_video_source">?</div><!-- class="wc_help_button" -->
-	          </div><!-- class="form_video_source" -->
-
             <div class="form_video_collection">
                 <div class="form_video_collection_title">
                     <label for="id_collection">Collection:</label>
@@ -80,23 +68,6 @@
 			              <div class="section-header">
 			                  Video file <div id="help_video_file" class="wc_help_button floatright" style="margin-right: 0px; margin-top: 5px;">?</div><!-- class="wc_help_button" -->
 			              </div>
-			              <input type="hidden" name="scan_directory"
-			                     value="{{scan_directory}}" />
-                    {% if scan_directory %}			
-                        <div class="fieldwrapper inlinewrapper">
-			                      <label for="id_source_file">Upload:</label>
-			                      {% if file_listing %}
-			                          <select name="source_file" id="id_source_file"> 
-			                              <option value="" selected="selected">---------</option> 
-			                              {% for file in file_listing %}
-			                                  <option value="{{file}}">{{file}}</option> 
-			                              {% endfor %}
-			                          </select> 
-			                      {% else %}
-			                          <p>There are no files in the drop-off directory</p>
-			                      {% endif %}
-		                    </div>
-                    {% else %}
 			                  <div class="fieldwrapper">
                             <p id="status"><b>Please select a file</b></p>
                              <input type="file" id="file" onchange="s3_upload();"/>
@@ -106,7 +77,6 @@
 
                         <script type="text/javascript">
                         </script>
-                    {% endif %}
 		                
 			              <div class="fieldwrapper inlinewrapper">
 			                  <label for="id_creator">Creator:</label>


### PR DESCRIPTION
once users are going straight to s3, it doesn't make sense for WC to
have a drop-off directory feature. We'll need to completely rethink that
use-case for S3 (really, it should be simpler; the video team will just
have access to a designated bucket and decent tools to drop files there,
then we can build a fairly simple interface that works off the list of
files in that bucket)