### PR TITLE
waffle flag for s3upload

### DIFF
--- a/wardenclyffe/main/tests/test_views.py
+++ b/wardenclyffe/main/tests/test_views.py
@@ -76,11 +76,6 @@ class SimpleTest(TestCase):
         response = self.c.get("/scan_directory/")
         self.assertEquals(response.status_code, 200)
 
-    def test_s3upload_form(self):
-        self.c.login(username=self.u.username, password="bar")
-        response = self.c.get("/s3upload/")
-        self.assertEquals(response.status_code, 200)
-
     def test_batch_upload_form(self):
         self.c.login(username=self.u.username, password="bar")
         response = self.c.get("/upload/batch/")

--- a/wardenclyffe/templates/main/batch_upload.html
+++ b/wardenclyffe/templates/main/batch_upload.html
@@ -4,16 +4,19 @@
 {% block pagetitle %}{% if scan_directory %}Add Video from Drop-off Directory{% else %}Add Video from Desktop{% endif %}{% endblock %}
 
 {% block extra_head %}
-<script type="text/javascript" src="{{STATIC_URL}}js/jquery.autocomplete.min.js"></script>
-
-<script type="text/javascript" src="{{STATIC_URL}}js/plupload.full.min.js"></script>
+    <script type="text/javascript" src="{{STATIC_URL}}js/jquery.autocomplete.min.js"></script>
+    {% flag s3upload %}
+    <script src="{{STATIC_URL}}js/libs/s3upload.js"></script>
+    {% else %}
+    <script type="text/javascript" src="{{STATIC_URL}}js/plupload.full.min.js"></script>
+    {% endflag %}
 
 {% endblock %}
 
 {% block content %}
 
-{% flag allow_uploads %}
-<form action="/upload/batch/post/" method="post" enctype="multipart/form-data">
+    {% flag allow_uploads %}
+    <form action="/upload/batch/post/" method="post" enctype="multipart/form-data">
 
 <div class="panel_top">
 

--- a/wardenclyffe/templates/main/single_upload.html
+++ b/wardenclyffe/templates/main/single_upload.html
@@ -1,3 +1,4 @@
+{% load waffle_tags %}
 <div class="panel_middle">
 	<div class="leftcol">
 		<div class="sectionbox">
@@ -23,11 +24,16 @@
 			Video file 
 			</div>
 			<div class="fieldwrapper">
+        {% flag s3upload %}
+        <p id="status-{{idx}}"><b>Please select a file</b></p>
+        <input type="file" id="file-{{idx}}" onchange="s3_upload_{{idx}}();"/>
+        <input type="hidden" name="s3url_{{idx}}" id="uploaded-url-{{idx}}" />
+        {% else %}
 				<ul id="filelist_{{idx}}"></ul>
 				<a id="browse_{{idx}}" href="javascript:;">Select File</a>
         <input type="hidden" name="tmpfilename_{{idx}}" id="tmpfilename_{{idx}}" value="" />
-
 				<pre id="console_{{idx}}"></pre>
+        {% endflag %}
 			</div>
 
 <script type="text/javascript">
@@ -67,7 +73,25 @@
 
 
 <script type="text/javascript">
-jQuery(document).ready(function() 
+{% flag s3upload %}
+function s3_upload_{{idx}}() {
+    var s3upload = new S3Upload({
+        file_dom_selector: 'file-{{idx}}',
+        s3_sign_put_url: '/sign_s3/',
+        s3_object_name: $('#file-{{idx}}')[0].value,
+        onProgress: function(percent, message) {
+            $('#status-{{idx}}').html('Upload progress: ' + percent + '%' + message);
+        },
+        onFinishS3Put: function(url) {
+            $('#uploaded-url-{{idx}}').val(url);
+        },
+        onError: function(status) {
+            $('#status-{{idx}}').html('Upload error: ' + status);
+        }
+    });
+}
+{% else %}
+ jQuery(document).ready(function() 
     { 
 
 var uploader_{{idx}} = new plupload.Uploader({
@@ -117,5 +141,5 @@ uploader_{{idx}}.init();
 
    }
 );
-
+{% endflag %}
 </script>

--- a/wardenclyffe/templates/mediathread/mediathread.html
+++ b/wardenclyffe/templates/mediathread/mediathread.html
@@ -23,7 +23,11 @@
 <script type="text/javascript" src="{{STATIC_URL}}js/jquery.autocomplete.min.js"></script>
 <link rel="stylesheet" type="text/css" href="{{STATIC_URL}}css/jquery.tagsinput.css" />
 <link rel="stylesheet" type="text/css" href="{{STATIC_URL}}css/jquery.autocomplete.css" />
+{% flag s3upload %}
+<script src="{{STATIC_URL}}js/libs/s3upload.js"></script>
+{% else %}
 <script type="text/javascript" src="{{STATIC_URL}}js/plupload.full.min.js"></script>
+{% endflag %}
 {% endcompress %}
 
 </head>
@@ -77,10 +81,16 @@
                                 <td class="step">
                                     <h4 id="upload_area">SELECT {% if audio %}audio{% else %}video{% endif %} file to upload {% if audio %}(.mp3){% else %}(.mov, .mp4, .avi){% endif %}</h4>
                                     <div>
-                                    <ul id="filelist"></ul>
-                                    <a id="browse" href="javascript:;">Select File</a>
-                                    <input type="hidden" name="tmpfilename" id="tmpfilename" value="" />
-                                    <pre id="console"></pre>
+                                        {% flag s3upload %}
+                                        <p id="status"><b>Please select a file</b></p>
+                                        <input type="file" id="file" onchange="s3_upload();"/>
+                                        <input type="hidden" name="s3_url" id="uploaded-url" />
+                                        {% else %}
+                                        <ul id="filelist"></ul>
+                                        <a id="browse" href="javascript:;">Select File</a>
+                                        <input type="hidden" name="tmpfilename" id="tmpfilename" value="" />
+                                        <pre id="console"></pre>
+                                        {% endflag %}
                                     </div>
                                 </td>
                             </tr>
@@ -136,6 +146,25 @@
 
 </div>
 <script type="text/javascript">
+ {% flag s3upload %}
+ function s3_upload() {
+    var s3upload = new S3Upload({
+        file_dom_selector: 'file',
+        s3_sign_put_url: '/sign_s3/',
+        s3_object_name: $('#file')[0].value,
+        onProgress: function(percent, message) {
+            $('#status').html('Upload progress: ' + percent + '%' + message);
+        },
+        onFinishS3Put: function(url) {
+            $('#uploaded-url').val(url);
+            $("#submit").removeAttr("disabled");            
+        },
+        onError: function(status) {
+            $('#status').html('Upload error: ' + status);
+        }
+    });
+}
+ {% else %}
 jQuery(document).ready(function() { 
     var uploader = new plupload.Uploader({
         browse_button: 'browse', // this can be an id of a DOM element or the DOM element itself
@@ -180,6 +209,7 @@ jQuery(document).ready(function() {
     });
 
     uploader.init();
-});
+ });
+ {% endflag %}
 </script>
 </body>

--- a/wardenclyffe/urls.py
+++ b/wardenclyffe/urls.py
@@ -77,8 +77,6 @@ urlpatterns = patterns(
     (r'^upload/post/$', 'wardenclyffe.main.views.upload'),
     (r'^upload/$', views.UploadFormView.as_view()),
 
-    (r'^s3upload/$', views.UploadFormView.as_view(
-        template_name='main/s3upload.html')),
     (r'^s3upload/post/$', 'wardenclyffe.main.views.s3upload'),
 
     (r'^upload/batch/$', views.BatchUploadFormView.as_view()),


### PR DESCRIPTION
made an 's3upload' flag in wardencflyffe admin, currently disabled for
everyone.

this implements s3upload across all the forms (including batch uploads
and mediathread upload), toggled by that flag. So
once this is out, we can enable the flag for admins or individual users
to begin testing the full workflow.