### PR TITLE
remove waffle flags from compress blocks

### DIFF
--- a/wardenclyffe/templates/main/batch_upload.html
+++ b/wardenclyffe/templates/main/batch_upload.html
@@ -5,11 +5,8 @@
 
 {% block extra_head %}
     <script type="text/javascript" src="{{STATIC_URL}}js/jquery.autocomplete.min.js"></script>
-    {% flag s3upload %}
     <script src="{{STATIC_URL}}js/libs/s3upload.js"></script>
-    {% else %}
     <script type="text/javascript" src="{{STATIC_URL}}js/plupload.full.min.js"></script>
-    {% endflag %}
 
 {% endblock %}
 

--- a/wardenclyffe/templates/mediathread/mediathread.html
+++ b/wardenclyffe/templates/mediathread/mediathread.html
@@ -23,11 +23,8 @@
 <script type="text/javascript" src="{{STATIC_URL}}js/jquery.autocomplete.min.js"></script>
 <link rel="stylesheet" type="text/css" href="{{STATIC_URL}}css/jquery.tagsinput.css" />
 <link rel="stylesheet" type="text/css" href="{{STATIC_URL}}css/jquery.autocomplete.css" />
-{% flag s3upload %}
 <script src="{{STATIC_URL}}js/libs/s3upload.js"></script>
-{% else %}
 <script type="text/javascript" src="{{STATIC_URL}}js/plupload.full.min.js"></script>
-{% endflag %}
 {% endcompress %}
 
 </head>


### PR DESCRIPTION
keep forgetting that. conditionals and compressor leads to this:

https://sentry.ccnmtl.columbia.edu/sentry-internal/wardenclyffe/group/1030/

So, just load both JS files. Testing locally, they appear to not
interfere with each other.