### PR TITLE
limit file uploads to video/audio

### DIFF
--- a/wardenclyffe/templates/main/s3upload.html
+++ b/wardenclyffe/templates/main/s3upload.html
@@ -70,7 +70,7 @@
 			              </div>
 			                  <div class="fieldwrapper">
                             <p id="status"><b>Please select a file</b></p>
-                             <input type="file" id="file" onchange="s3_upload();"/>
+                            <input type="file" id="file" onchange="s3_upload();" accept=".mov,.avi,.mp4,.flv,.mpg,.wmv,.m4v,.mp3" />
                              <input type="hidden" name="s3_url" id="uploaded-url" />
 				                    <pre id="console"></pre>
 			                  </div>

--- a/wardenclyffe/templates/main/single_upload.html
+++ b/wardenclyffe/templates/main/single_upload.html
@@ -26,7 +26,7 @@
 			<div class="fieldwrapper">
         {% flag s3upload %}
         <p id="status-{{idx}}"><b>Please select a file</b></p>
-        <input type="file" id="file-{{idx}}" onchange="s3_upload_{{idx}}();"/>
+        <input type="file" id="file-{{idx}}" onchange="s3_upload_{{idx}}();" accept=".mov,.avi,.mp4,.flv,.mpg,.wmv,.m4v,.mp3"/>
         <input type="hidden" name="s3url_{{idx}}" id="uploaded-url-{{idx}}" />
         {% else %}
 				<ul id="filelist_{{idx}}"></ul>

--- a/wardenclyffe/templates/mediathread/mediathread.html
+++ b/wardenclyffe/templates/mediathread/mediathread.html
@@ -80,7 +80,11 @@
                                     <div>
                                         {% flag s3upload %}
                                         <p id="status"><b>Please select a file</b></p>
-                                        <input type="file" id="file" onchange="s3_upload();"/>
+                                        {% if audio %}
+                                            <input type="file" id="file" onchange="s3_upload();" accept=".mp3" />                                            
+                                        {% else %}
+                                            <input type="file" id="file" onchange="s3_upload();" accept=".mov,.avi,.mp4,.flv,.mpg,.wmv,.m4v" />
+                                        {% endif %}
                                         <input type="hidden" name="s3_url" id="uploaded-url" />
                                         {% else %}
                                         <ul id="filelist"></ul>


### PR DESCRIPTION
on the mediathread upload form, we actually know if they're supposed to
be uploading a video or an audio file and can limit accordingly. on the
regular upload, we don't necessarily know until we know which collection
they are uploading to, which we have no way of knowing yet, so we have
to allow both video and audio types.