### PR TITLE
prevent batch upload without collection set

### DIFF
--- a/wardenclyffe/main/tests/test_views.py
+++ b/wardenclyffe/main/tests/test_views.py
@@ -133,7 +133,7 @@ class SimpleTest(TestCase):
         self.assertEquals(response.status_code, 302)
 
         # invalid form
-        response = self.c.post("/upload/batch/post/")
+        response = self.c.post("/upload/batch/post/", dict(collection=1))
         self.assertEquals(response.status_code, 302)
 
     def test_subject_autocomplete(self):

--- a/wardenclyffe/main/views.py
+++ b/wardenclyffe/main/views.py
@@ -745,6 +745,11 @@ def batch_upload(request):
     statsd.incr('main.batch_upload')
     collection_id = request.POST.get('collection', None)
 
+    if collection_id is None:
+        # javascript should prevent this from happening
+        # but...
+        return HttpResponse("need to pick a collection")
+
     try:
         if waffle.flag_is_active(request, 's3upload'):
             operations = s3_batch_upload(request, collection_id)

--- a/wardenclyffe/templates/main/batch_upload.html
+++ b/wardenclyffe/templates/main/batch_upload.html
@@ -36,7 +36,6 @@
 window.copyDown = function(base, idx) {
   var source = $("#" + base + idx);
   var value = source.val();
-  console.log(base, idx, value);
   $(":input").each(function () {
      if (this.id.indexOf(base) == 0) {
         var rest = this.id.substring(base.length);
@@ -46,7 +45,33 @@ window.copyDown = function(base, idx) {
      }
    }
   );
-}
+ }
+
+ {% if collection_id %}
+ window.collectionSelected = true;
+ {% else %}
+ window.collectionSelected = false;
+ {% endif %}
+
+ window.oneOrMoreFiles = false;
+
+ window.updateSubmit = function() {
+     if (window.collectionSelected && window.oneOrMoreFiles) {
+	       $("#submit").removeAttr("disabled");
+     } else {
+	       $("#submit").attr("disabled", "disabled");
+     }
+ };
+
+ window.collectionUpdate = function(e) {
+     window.collectionSelected = $('#id_collection').val() != '';
+     window.updateSubmit();
+ }
+
+ $(function () {
+     $('#id_collection').change(collectionUpdate);
+ });
+ 
 </script>
 
 {% with idx=1 %}

--- a/wardenclyffe/templates/main/batch_upload.html
+++ b/wardenclyffe/templates/main/batch_upload.html
@@ -34,44 +34,43 @@
 
 <script>
 window.copyDown = function(base, idx) {
-  var source = $("#" + base + idx);
-  var value = source.val();
-  $(":input").each(function () {
-     if (this.id.indexOf(base) == 0) {
-        var rest = this.id.substring(base.length);
-        if (rest > idx) {
-           $(this).val(value);
+    var source = $("#" + base + idx);
+    var value = source.val();
+    $(":input").each(function () {
+        if (this.id.indexOf(base) == 0) {
+            var rest = this.id.substring(base.length);
+            if (rest > idx) {
+                $(this).val(value);
+            }
         }
-     }
-   }
-  );
- }
+    }
+    );
+}
 
- {% if collection_id %}
- window.collectionSelected = true;
- {% else %}
- window.collectionSelected = false;
- {% endif %}
+{% if collection_id %}
+window.collectionSelected = true;
+{% else %}
+window.collectionSelected = false;
+{% endif %}
 
- window.oneOrMoreFiles = false;
+window.oneOrMoreFiles = false;
 
- window.updateSubmit = function() {
-     if (window.collectionSelected && window.oneOrMoreFiles) {
-	       $("#submit").removeAttr("disabled");
-     } else {
-	       $("#submit").attr("disabled", "disabled");
-     }
- };
+window.updateSubmit = function() {
+    if (window.collectionSelected && window.oneOrMoreFiles) {
+        $("#submit").removeAttr("disabled");
+    } else {
+        $("#submit").attr("disabled", "disabled");
+    }
+};
 
- window.collectionUpdate = function(e) {
-     window.collectionSelected = $('#id_collection').val() != '';
-     window.updateSubmit();
- }
+window.collectionUpdate = function(e) {
+    window.collectionSelected = $('#id_collection').val() != '';
+    window.updateSubmit();
+}
 
- $(function () {
-     $('#id_collection').change(collectionUpdate);
- });
- 
+$(function () {
+    $('#id_collection').change(collectionUpdate);
+});
 </script>
 
 {% with idx=1 %}

--- a/wardenclyffe/templates/main/single_upload.html
+++ b/wardenclyffe/templates/main/single_upload.html
@@ -84,6 +84,8 @@ function s3_upload_{{idx}}() {
         },
         onFinishS3Put: function(url) {
             $('#uploaded-url-{{idx}}').val(url);
+	          window.oneOrMoreFiles = true;
+            window.updateSubmit();
         },
         onError: function(status) {
             $('#status-{{idx}}').html('Upload error: ' + status);
@@ -134,7 +136,8 @@ uploader_{{idx}}.bind('Error', function(up, err) {
 uploader_{{idx}}.bind('FileUploaded', function(up, data, r) {
 	console.log(r.response);
 	$("#tmpfilename_{{idx}}").val(r.response);
-	$("#submit").removeAttr("disabled");
+	window.oneOrMoreFiles = true;
+  window.updateSubmit();
 });
 
 uploader_{{idx}}.init();

--- a/wardenclyffe/templates/main/single_upload.html
+++ b/wardenclyffe/templates/main/single_upload.html
@@ -84,7 +84,7 @@ function s3_upload_{{idx}}() {
         },
         onFinishS3Put: function(url) {
             $('#uploaded-url-{{idx}}').val(url);
-	          window.oneOrMoreFiles = true;
+            window.oneOrMoreFiles = true;
             window.updateSubmit();
         },
         onError: function(status) {
@@ -93,56 +93,56 @@ function s3_upload_{{idx}}() {
     });
 }
 {% else %}
- jQuery(document).ready(function() 
-    { 
+jQuery(document).ready(function()
+    {
 
-var uploader_{{idx}} = new plupload.Uploader({
-	  browse_button: 'browse_{{idx}}', // this can be an id of a DOM element or the DOM element itself
-  	url: '/uploadify/',
-	  max_retries: 3,
-  	multi_selection: false,
-  	runtimes : 'html5,flash,silverlight',
-  	flash_swf_url: '{{STATIC_URL}}js/Moxie.swf',
-  	silverlight_xap_url: '{{STATIC_URL}}js/Moxie.xap',
-    filters: {
-		mime_types : [
-  		{ title : "Audio files", extensions : "mp3" },
-  		{ title : "Video Files", extensions : "mov,avi,mp4,flv,mpg,wmv,m4v" }
-		]
-	}
-});
+        var uploader_{{idx}} = new plupload.Uploader({
+            browse_button: 'browse_{{idx}}', // this can be an id of a DOM element or the DOM element itself
+            url: '/uploadify/',
+            max_retries: 3,
+            multi_selection: false,
+            runtimes : 'html5,flash,silverlight',
+            flash_swf_url: '{{STATIC_URL}}js/Moxie.swf',
+            silverlight_xap_url: '{{STATIC_URL}}js/Moxie.xap',
+            filters: {
+                mime_types : [
+                    { title : "Audio files", extensions : "mp3" },
+                    { title : "Video Files", extensions : "mov,avi,mp4,flv,mpg,wmv,m4v" }
+                ]
+            }
+        });
 
-uploader_{{idx}}.bind('FilesAdded', function(up, files) {
-    console.log("files added");
-    var html = '';
-		plupload.each(files, function(file) {
-		    html += '<li id="' + file.id + '">' + file.name + ' (' + plupload.formatSize(file.size) + ') <b></b></li>';
-		});
-		document.getElementById('filelist_{{idx}}').innerHTML += html;
-   // only allow one file at a time, and start uploading automatically
-   $("#browse_{{idx}}").replaceWith();
-	up.start();
-});
+        uploader_{{idx}}.bind('FilesAdded', function(up, files) {
+            console.log("files added");
+            var html = '';
+            plupload.each(files, function(file) {
+                html += '<li id="' + file.id + '">' + file.name + ' (' + plupload.formatSize(file.size) + ') <b></b></li>';
+            });
+            document.getElementById('filelist_{{idx}}').innerHTML += html;
+            // only allow one file at a time, and start uploading automatically
+            $("#browse_{{idx}}").replaceWith();
+            up.start();
+        });
 
-uploader_{{idx}}.bind('UploadProgress', function(up, file) {
-	document.getElementById(file.id).getElementsByTagName('b')[0].innerHTML = '<span>' + file.percent + "%</span>";
-});
+        uploader_{{idx}}.bind('UploadProgress', function(up, file) {
+            document.getElementById(file.id).getElementsByTagName('b')[0].innerHTML = '<span>' + file.percent + "%</span>";
+        });
 
-uploader_{{idx}}.bind('Error', function(up, err) {
-	console.log(err);
-	document.getElementById('console_{{idx}}').innerHTML += "\nError #" + err.code + ": " + err.message;
-});
+        uploader_{{idx}}.bind('Error', function(up, err) {
+            console.log(err);
+            document.getElementById('console_{{idx}}').innerHTML += "\nError #" + err.code + ": " + err.message;
+        });
 
-uploader_{{idx}}.bind('FileUploaded', function(up, data, r) {
-	console.log(r.response);
-	$("#tmpfilename_{{idx}}").val(r.response);
-	window.oneOrMoreFiles = true;
-  window.updateSubmit();
-});
+        uploader_{{idx}}.bind('FileUploaded', function(up, data, r) {
+            console.log(r.response);
+            $("#tmpfilename_{{idx}}").val(r.response);
+            window.oneOrMoreFiles = true;
+            window.updateSubmit();
+        });
 
-uploader_{{idx}}.init();
+        uploader_{{idx}}.init();
 
-   }
+    }
 );
 {% endflag %}
 </script>


### PR DESCRIPTION
Addressing:

https://sentry.ccnmtl.columbia.edu/sentry-internal/wardenclyffe/group/1043/

added some basic JS validation to keep the submit button on the batch
upload form disabled until both a collection has been selected and one
or more videos have been uploaded (to s3 or plupload).