### PR TITLE
remove the `encode_audio` waffle flag

### DIFF
--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -347,7 +347,7 @@ class Video(TimeStampedModel):
                                    location_type='none')
 
     def make_default_operations(self, tmpfilename, source_file, user,
-                                audio=False, audio_flag=True):
+                                audio=False):
         operations = [self.make_save_file_to_s3_operation(
             tmpfilename, user, audio=audio)]
         return operations

--- a/wardenclyffe/mediathread/tests/test_views.py
+++ b/wardenclyffe/mediathread/tests/test_views.py
@@ -3,7 +3,6 @@ from django.test.client import Client
 import hmac
 import hashlib
 from django.conf import settings
-from waffle.testutils import override_flag
 from wardenclyffe.mediathread.views import mediathread_post, s3_upload
 from wardenclyffe.main.tests.factories import (
     UserFactory, CollectionFactory)
@@ -70,7 +69,6 @@ class TestS3Upload(TestCase):
             response = s3_upload(r)
             self.assertEqual(response.status_code, 302)
 
-    @override_flag('encode_audio', active=True)
     def test_audio(self):
         u = UserFactory()
         c = CollectionFactory()

--- a/wardenclyffe/mediathread/views.py
+++ b/wardenclyffe/mediathread/views.py
@@ -102,10 +102,8 @@ def normal_upload(request):
                 request.session['redirect_to'], audio=audio,
             )
 
-            audio_flag = waffle.flag_is_active(request, 'encode_audio')
             operations = v.make_default_operations(
-                tmpfilename, source_file, user, audio=audio,
-                audio_flag=audio_flag)
+                tmpfilename, source_file, user, audio=audio)
         except:
             statsd.incr("mediathread.mediathread.failure")
             raise
@@ -147,13 +145,12 @@ def s3_upload(request):
             request.session['redirect_to'], audio=audio,
         )
 
-        audio_flag = waffle.flag_is_active(request, 'encode_audio')
         label = "uploaded source file (S3)"
-        if audio_flag and audio:
+        if audio:
             label = "uploaded source audio (S3)"
         File.objects.create(video=v, url="", cap=key, location_type="s3",
                             filename=key, label=label)
-        if audio_flag and audio:
+        if audio:
             operations = [v.make_local_audio_encode_operation(
                 key, user=user)]
         else:


### PR DESCRIPTION
It's been on for months now and I don't see us needing to disable audio
encoding in a hurry, so I think we can get rid of that code path.

Once this is merged, someone should then go into WC's admin and delete
the flag.