### PR TITLE
Youtube upload retry bugfix

### DIFF
--- a/wardenclyffe/youtube/util.py
+++ b/wardenclyffe/youtube/util.py
@@ -149,12 +149,13 @@ def resumable_upload(insert_request):
         except RETRIABLE_EXCEPTIONS, e:
             error = "A retriable error occurred: %s" % e
 
-        if error is not None:
-            retry = handle_upload_error(error, retry)
+        retry = handle_upload_error(error, retry)
     return youtube_id
 
 
 def handle_upload_error(error, retry):
+    if error is None:
+        return retry
     print error
     retry += 1
     if retry > MAX_RETRIES:

--- a/wardenclyffe/youtube/util.py
+++ b/wardenclyffe/youtube/util.py
@@ -126,36 +126,32 @@ def initialize_upload(youtube, options):
 # failed upload.
 def resumable_upload(insert_request):
     response = None
+    error = None
     retry = 0
     youtube_id = None
     while response is None:
-        youtube_id, error = try_upload(insert_request)
+        try:
+            print "Uploading file..."
+            status, response = insert_request.next_chunk()
+            if 'id' in response:
+                print("Video id '%s' was successfully uploaded."
+                      % response['id'])
+                youtube_id = response['id']
+            else:
+                exit("The upload failed with an unexpected response: %s"
+                     % response)
+        except HttpError, e:
+            if e.resp.status in RETRIABLE_STATUS_CODES:
+                error = "A retriable HTTP error %d occurred:\n%s" % (
+                    e.resp.status, e.content)
+            else:
+                raise
+        except RETRIABLE_EXCEPTIONS, e:
+            error = "A retriable error occurred: %s" % e
+
         if error is not None:
             retry = handle_upload_error(error, retry)
     return youtube_id
-
-
-def try_upload(insert_request):
-    error = None
-    try:
-        print "Uploading file..."
-        status, response = insert_request.next_chunk()
-        if 'id' in response:
-            print("Video id '%s' was successfully uploaded."
-                  % response['id'])
-            youtube_id = response['id']
-        else:
-            exit("The upload failed with an unexpected response: %s"
-                 % response)
-    except HttpError, e:
-        if e.resp.status in RETRIABLE_STATUS_CODES:
-            error = "A retriable HTTP error %d occurred:\n%s" % (
-                e.resp.status, e.content)
-        else:
-            raise
-    except RETRIABLE_EXCEPTIONS, e:
-        error = "A retriable error occurred: %s" % e
-    return youtube_id, error
 
 
 def handle_upload_error(error, retry):


### PR DESCRIPTION
revert a previous refactoring that broke some of the retry logic on resumable youtube uploads.