### PR TITLE
remove imports from test __init__.py files

### DIFF
--- a/wardenclyffe/graphite/tests/__init__.py
+++ b/wardenclyffe/graphite/tests/__init__.py
@@ -1,2 +1,0 @@
-# flake8: noqa
-from .test_models import *

--- a/wardenclyffe/main/tests/__init__.py
+++ b/wardenclyffe/main/tests/__init__.py
@@ -1,4 +1,0 @@
-# flake8: noqa
-from test_models import *
-from test_views import *
-from test_tasks import *

--- a/wardenclyffe/mediathread/tests/__init__.py
+++ b/wardenclyffe/mediathread/tests/__init__.py
@@ -1,2 +1,0 @@
-# flake8: noqa
-from test_views import *

--- a/wardenclyffe/youtube/tests/__init__.py
+++ b/wardenclyffe/youtube/tests/__init__.py
@@ -1,2 +1,0 @@
-# flake8: noqa
-from test_views import *


### PR DESCRIPTION
don't need to manually import tests like that anymore