### PR TITLE
dropbox SNS debug view

### DIFF
--- a/wardenclyffe/drop/urls.py
+++ b/wardenclyffe/drop/urls.py
@@ -1,0 +1,9 @@
+from django.conf.urls import patterns, url
+
+from .views import SNSView
+
+
+urlpatterns = patterns(
+    '',
+    url(r'^sns/$', SNSView.as_view(), name='drop-sns-endpoint'),
+)

--- a/wardenclyffe/drop/views.py
+++ b/wardenclyffe/drop/views.py
@@ -1,0 +1,19 @@
+from django.core.mail import send_mail
+from django.http import HttpResponse
+from django.views.generic.base import View
+
+
+class SNSView(View):
+    def post(self, request):
+        request_body = request.read()
+        request_meta = str(request.META)
+
+        body = "{}\n\n\n{}".format(request_meta, request_body)
+
+        send_mail(
+            "SNS Debug",
+            body,
+            "snsdebug@wardenclyffe.ccnmtl.columbia.edu",
+            ["anders@columbia.edu"],
+            fail_silently=False)
+        return HttpResponse("OK")

--- a/wardenclyffe/urls.py
+++ b/wardenclyffe/urls.py
@@ -16,6 +16,7 @@ urlpatterns = patterns(
     ('^most_recent_operation/', views.MostRecentOperationView.as_view()),
     ('^accounts/', include('djangowind.urls')),
     (r'^admin/', include(admin.site.urls)),
+    (r'^drop/', include('wardenclyffe.drop.urls')),
     (r'^capture/file_upload', 'wardenclyffe.main.views.test_upload'),
     (r'^add_collection/$', views.AddCollectionView.as_view()),
     (r'^collection/(?P<pk>\d+)/$', views.CollectionView.as_view()),


### PR DESCRIPTION
This is purely for information gathering. When SNS sends a message to
this endpoint, it just reads in the request and emails it to me so I can
see what they are sending.

The eventual goal is to create an SNS topic that passes along events
when files are uploaded to the S3 drop bucket, then to subscribe this
URL to that SNS topic.

What I discovered previously, doing SNS subscriptions on the elastic
transcoder workflow was that the AWS documentation is thin and confusing
when it comes to the exact format of the message payload that they send
you. The simplest approach is just to put something like this up and
trigger a few events and just see what you get back and figure out from
there what headers and message fields are actually useful for
identifying and routing.

So this whole view as it exists is intended to be disposable. Once it's
deployed and I hit it with some test data, it will be replaced with the
beginnings of the actual endpoint that kicks off a pipeline, etc.