### PR TITLE
link StreamLogs back to matching Video

### DIFF
--- a/wardenclyffe/streamlogs/models.py
+++ b/wardenclyffe/streamlogs/models.py
@@ -32,7 +32,7 @@ class StreamLog(models.Model):
         return None
 
     def full_filename(self):
-        # unofortunately, streamlogs filenames start with a 'broadcast/'
+        # unfortunately, streamlogs filenames start with a 'broadcast/'
         # and the broadcast directory also includes it. So we need to
         # to strip it first.
         pattern = re.compile(r'^broadcast/')

--- a/wardenclyffe/streamlogs/tests/test_models.py
+++ b/wardenclyffe/streamlogs/tests/test_models.py
@@ -1,4 +1,6 @@
+from django.conf import settings
 from django.test import TestCase
+from wardenclyffe.main.tests.factories import FileFactory
 from .factories import StreamLogFactory
 
 
@@ -6,3 +8,21 @@ class StreamLogTest(TestCase):
     def test_create(self):
         f = StreamLogFactory()
         self.assertIsNotNone(f)
+
+    def test_full_filename(self):
+        f = StreamLogFactory(filename='broadcast/foo/bar.flv')
+        self.assertEqual(
+            f.full_filename(),
+            settings.CUNIX_BROADCAST_DIRECTORY + "foo/bar.flv")
+
+    def test_video_no_match(self):
+        f = StreamLogFactory()
+        self.assertIsNone(f.video())
+
+    def test_video_positive_match(self):
+        s = StreamLogFactory(filename="broadcast/foo/bar.flv")
+        f = FileFactory(
+            filename=settings.CUNIX_BROADCAST_DIRECTORY + "foo/bar.flv",
+            location_type='cuit')
+        print(f.filename)
+        self.assertEqual(s.video(), f.video)

--- a/wardenclyffe/streamlogs/tests/test_models.py
+++ b/wardenclyffe/streamlogs/tests/test_models.py
@@ -24,5 +24,4 @@ class StreamLogTest(TestCase):
         f = FileFactory(
             filename=settings.CUNIX_BROADCAST_DIRECTORY + "foo/bar.flv",
             location_type='cuit')
-        print(f.filename)
         self.assertEqual(s.video(), f.video)

--- a/wardenclyffe/templates/streamlogs/streamlog_detail.html
+++ b/wardenclyffe/templates/streamlogs/streamlog_detail.html
@@ -9,6 +9,18 @@
                 <th>Timestamp</th><td>{{ object.request_at }}</td>
             </tr>
             <tr>
+                <th>Video</th>
+                <td>
+                    {% with video=object.video %}
+                        {% if video %}
+                            <a href="{% url 'video-details' video.pk %}">{{video.title}}</a>
+                        {% else %}
+                            No matching video in Wardenclyffe
+                        {% endif %}
+                    {% endwith %}
+                </td>
+            </tr>
+            <tr>
                 <th>Filename</th><td><tt>{{object.filename}}</tt></td>
             </tr>
             <tr>

--- a/wardenclyffe/urls.py
+++ b/wardenclyffe/urls.py
@@ -92,7 +92,7 @@ urlpatterns = [
     url(r'^youtube/done/$', youtube_views.youtube_done),
     url(r'^received/$', views.ReceivedView.as_view()),
     url(r'^surelink/$', views.SureLinkView.as_view()),
-    url(r'^video/$', views.VideoIndexView.as_view()),
+    url(r'^video/$', views.VideoIndexView.as_view(), name='video-details'),
     url(r'^video/(?P<pk>\d+)/$', views.VideoView.as_view()),
     url(r'^video/(?P<id>\d+)/youtube/$',
         views.VideoYoutubeUploadView.as_view(), name="s3-to-youtube"),


### PR DESCRIPTION
We have the filename in the `StreamLog` entry. If the video was uploaded
through WC, there will be a `File` somewhere with that filename, which
we can use to provide a link back to the `Video` entry.