### PR TITLE
Flv to mp4 single video conversion

### DIFF
--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -278,6 +278,10 @@ class Video(TimeStampedModel):
         return self.file_set.filter(
             location_type="cuit", filename__endswith='.flv').count() > 0
 
+    def has_mp4(self):
+        return self.file_set.filter(
+            location_type="cuit", filename__endswith='.mp4').count() > 0
+
     def is_audio_file(self):
         """ is this one of the weird mp3s that are
         uploaded to be converted to mp4s so clipping works?"""

--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -274,6 +274,10 @@ class Video(TimeStampedModel):
         except:
             return None
 
+    def has_flv(self):
+        return self.file_set.filter(
+            location_type="cuit", filename__endswith='.flv').count() > 0
+
     def is_audio_file(self):
         """ is this one of the weird mp3s that are
         uploaded to be converted to mp4s so clipping works?"""

--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -282,6 +282,10 @@ class Video(TimeStampedModel):
         return self.file_set.filter(
             location_type="cuit", filename__endswith='.mp4').count() > 0
 
+    def flv_convertable(self):
+        # there's an associated flv, but no mp4 yet
+        return self.has_flv() and not self.has_mp4()
+
     def is_audio_file(self):
         """ is this one of the weird mp3s that are
         uploaded to be converted to mp4s so clipping works?"""

--- a/wardenclyffe/main/tests/test_models.py
+++ b/wardenclyffe/main/tests/test_models.py
@@ -136,6 +136,9 @@ class EmptyVideoTest(TestCase):
     def test_has_mp4(self):
         self.assertFalse(self.video.has_mp4())
 
+    def test_flv_convertable(self):
+        self.assertFalse(self.video.flv_convertable())
+
     def test_make_source_file(self):
         f = self.video.make_source_file("somefile.mpg")
         self.assertEqual(f.filename, "somefile.mpg")

--- a/wardenclyffe/main/tests/test_models.py
+++ b/wardenclyffe/main/tests/test_models.py
@@ -133,6 +133,9 @@ class EmptyVideoTest(TestCase):
     def test_has_flv(self):
         self.assertFalse(self.video.has_flv())
 
+    def test_has_mp4(self):
+        self.assertFalse(self.video.has_mp4())
+
     def test_make_source_file(self):
         f = self.video.make_source_file("somefile.mpg")
         self.assertEqual(f.filename, "somefile.mpg")

--- a/wardenclyffe/main/tests/test_models.py
+++ b/wardenclyffe/main/tests/test_models.py
@@ -130,6 +130,9 @@ class EmptyVideoTest(TestCase):
     def test_cuit_file(self):
         assert self.video.cuit_file() is None
 
+    def test_has_flv(self):
+        self.assertFalse(self.video.has_flv())
+
     def test_make_source_file(self):
         f = self.video.make_source_file("somefile.mpg")
         self.assertEqual(f.filename, "somefile.mpg")

--- a/wardenclyffe/main/tests/test_views.py
+++ b/wardenclyffe/main/tests/test_views.py
@@ -248,6 +248,11 @@ class SimpleTest(TestCase):
         response = self.c.get("/operation/%s/info/" % o.uuid)
         self.assertEqual(response.status_code, 200)
 
+    def test_flv_to_mp4_convert(self):
+        v = VideoFactory()
+        response = self.c.post(reverse('video-flv-to-mp4', args=[v.pk]))
+        self.assertEquals(response.status_code, 302)
+
 
 class TestSurelink(TestCase):
     def setUp(self):

--- a/wardenclyffe/main/views.py
+++ b/wardenclyffe/main/views.py
@@ -761,6 +761,14 @@ class VideoYoutubeUploadView(StaffMixin, View):
         return HttpResponseRedirect(video.get_absolute_url())
 
 
+class FlvToMp4View(StaffMixin, View):
+    def post(self, request, id):
+        video = get_object_or_404(Video, id=id)
+        o = video.make_flv_to_mp4_operation(request.user)
+        tasks.process_operation.delay(o.id)
+        return HttpResponseRedirect(video.get_absolute_url())
+
+
 class AudioEncodeFileView(StaffMixin, View):
     def post(self, request, pk):
         f = get_object_or_404(File, pk=pk)

--- a/wardenclyffe/templates/main/video.html
+++ b/wardenclyffe/templates/main/video.html
@@ -183,9 +183,15 @@ var removeTag = function(tagName,tagId) {
 
 {% flag "s3_to_youtube" %}
 <form action="{% url 's3-to-youtube' video.id %}" method="post">
-  <input type="submit" value="pull from S3 and upload to youtube" />
+    <input type="submit" value="pull from S3 and upload to youtube" />
 </form>
 {% endflag %}
+
+{% if video.flv_convertable %}
+    <form action="{% url 'video-flv-to-mp4}' video.id %}" method="post">
+        <input type="submit" value="convert flv to mp4" />        
+    </form>
+{% endif %}
 </div>
 </div>
 <script>

--- a/wardenclyffe/urls.py
+++ b/wardenclyffe/urls.py
@@ -96,6 +96,8 @@ urlpatterns = [
     url(r'^video/(?P<pk>\d+)/$', views.VideoView.as_view()),
     url(r'^video/(?P<id>\d+)/youtube/$',
         views.VideoYoutubeUploadView.as_view(), name="s3-to-youtube"),
+    url(r'^video/(?P<id>\d+)/flv2mp4/$',
+        views.FlvToMp4View.as_view(), name="video-flv-to-mp4"),
     url(r'^video/(?P<id>\d+)/mediathread_submit/$',
         mediathread_views.VideoMediathreadSubmit.as_view()),
     url(r'^video/(?P<id>\d+)/add_file/$', views.VideoAddFileView.as_view()),


### PR DESCRIPTION
Adds a "flv to mp4" button on videos that have an attached flv, but no mp4. that will kick off a conversion for that one video.

Mostly, we want to be doing conversions in batch operations but this is a good place to start, and the functionality here will be needed in batch mode anyway.