### PR TITLE
optimize flv conversion when there's already an S3

### DIFF
--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -109,6 +109,9 @@ class Video(TimeStampedModel):
         else:
             return None
 
+    def has_s3_source(self):
+        return self.s3_file() is not None
+
     def s3_key(self):
         t = self.s3_file()
         if t:

--- a/wardenclyffe/main/tests/test_models.py
+++ b/wardenclyffe/main/tests/test_models.py
@@ -136,6 +136,9 @@ class EmptyVideoTest(TestCase):
     def test_has_mp4(self):
         self.assertFalse(self.video.has_mp4())
 
+    def test_has_s3_source(self):
+        self.assertFalse(self.video.has_s3_source())
+
     def test_flv_convertable(self):
         self.assertFalse(self.video.flv_convertable())
 


### PR DESCRIPTION
Some of the flvs do have an original source S3 file already up
there. For these, there's no need to pull the flv file down off cunix
and upload that to S3. The encoding should also come out better since
it's re-encoding from the original source instead of transcoding.