### PR TITLE
link videos back to streamlogs

### DIFF
--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -1,23 +1,25 @@
+import base64
+import hmac
+import os.path
+import sha
+import time
+import urllib
+import uuid
+
+from django import forms
+from django.apps import apps
+from django.conf import settings
+from django.contrib.auth.models import User
 from django.db import models
 from django_extensions.db.fields import UUIDField
 from django_extensions.db.models import TimeStampedModel
-from django.contrib.auth.models import User
-from django import forms
-from taggit.managers import TaggableManager
-from surelink import SureLink
-from surelink.helpers import PROTECTION_OPTIONS
-from surelink.helpers import AUTHTYPE_OPTIONS
-from django.conf import settings
-import os.path
-from wardenclyffe.util.mail import send_failed_operation_mail
 from django_statsd.clients import statsd
-import uuid
-import time
-import hmac
-import sha
-import urllib
-import base64
 from json import dumps, loads
+from surelink import SureLink
+from surelink.helpers import AUTHTYPE_OPTIONS
+from surelink.helpers import PROTECTION_OPTIONS
+from taggit.managers import TaggableManager
+from wardenclyffe.util.mail import send_failed_operation_mail
 
 
 class Collection(TimeStampedModel):
@@ -300,6 +302,17 @@ class Video(TimeStampedModel):
                 location_type='mediathreadsubmit')[0].get_metadata('audio')
         except:
             return False
+
+    def streamlogs(self):
+        if not self.has_flv():
+            return None
+        filename = self.flv_filename()
+        # convert to the partial filename that streamlogs have
+        base = settings.CUNIX_BROADCAST_DIRECTORY
+        # strip off up to the 'broadcast/'
+        filename = filename.replace(base, "broadcast/")
+        StreamLog = apps.get_model('streamlogs', 'StreamLog')
+        return StreamLog.objects.filter(filename=filename)
 
     def make_mediathread_submit_file(self, filename, user, set_course,
                                      redirect_to, audio=False):

--- a/wardenclyffe/main/tests/test_models.py
+++ b/wardenclyffe/main/tests/test_models.py
@@ -139,6 +139,15 @@ class EmptyVideoTest(TestCase):
     def test_flv_convertable(self):
         self.assertFalse(self.video.flv_convertable())
 
+    def test_streamlogs_no_flv(self):
+        self.assertIsNone(self.video.streamlogs())
+
+    def test_streamlogs_with_flv(self):
+        CUITFLVFileFactory(video=self.video)
+        r = self.video.streamlogs()
+        self.assertIsNotNone(r)
+        self.assertEqual(r.count(), 0)
+
     def test_make_source_file(self):
         f = self.video.make_source_file("somefile.mpg")
         self.assertEqual(f.filename, "somefile.mpg")

--- a/wardenclyffe/templates/main/video.html
+++ b/wardenclyffe/templates/main/video.html
@@ -78,6 +78,28 @@ var removeTag = function(tagName,tagId) {
 <p><a href="edit/">edit video metadata</a></p>
 </td></tr></table>
 
+{% with streamlogs=video.streamlogs %}
+    {% if streamlogs %}
+        <h2>Recent Streams</h2>
+        <p>(only implemented for flv streaming currently)</p>
+        <table>
+            <thead>
+                <tr>
+                    <th>timestamp</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for object in streamlogs %}
+                    <tr>
+                        <td><a href="{% url 'streamlogs-detail' object.pk %}">{{object.request_at}}</a></td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+
+    {% endif %}
+{% endwith %}
+
 </div>
 
 


### PR DESCRIPTION
when you're viewing a video detail page, if there are corresponding
streamlogs for that video, show them.