### PR TITLE
Mediathread replace

### DIFF
--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -243,6 +243,10 @@ class Video(TimeStampedModel):
         return self.file_set.filter(
             location_type="mediathreadsubmit").count() > 0
 
+    def has_mediathread_asset(self):
+        return self.file_set.filter(
+            location_type="mediathread").count() > 0
+
     def mediathread_submit(self):
         r = self.file_set.filter(location_type="mediathreadsubmit")
         if r.count() > 0:

--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -247,6 +247,10 @@ class Video(TimeStampedModel):
         return self.file_set.filter(
             location_type="mediathread").count() > 0
 
+    def mediathread_asset_url(self):
+        return self.file_set.filter(
+            location_type="mediathread").first().url
+
     def mediathread_submit(self):
         r = self.file_set.filter(location_type="mediathreadsubmit")
         if r.count() > 0:
@@ -276,6 +280,16 @@ class Video(TimeStampedModel):
                 self.clear_mediathread_submit()
                 return [o]
         return []
+
+    def handle_mediathread_update(self):
+        if not self.has_mediathread_update():
+            return []
+        o = self.make_op(
+            User.objects.get(username=self.creator),
+            dict(),
+            action="update mediathread")
+        self.clear_mediathread_update()
+        return [o]
 
     def create_mediathread_update(self):
         """ add a temporary File that indicates that an update to Meth
@@ -854,6 +868,12 @@ class SubmitToMediathreadOperation(OperationType):
         return wardenclyffe.mediathread.tasks.submit_to_mediathread
 
 
+class UpdateMediathreadOperation(OperationType):
+    def get_task(self):
+        import wardenclyffe.mediathread.tasks
+        return wardenclyffe.mediathread.tasks.update_mediathread
+
+
 class PullFromS3AndUploadToYoutubeOperation(OperationType):
     def get_task(self):
         import wardenclyffe.youtube.tasks
@@ -864,6 +884,9 @@ class CreateElasticTranscoderJobOperation(OperationType):
     def get_task(self):
         import wardenclyffe.main.tasks
         return wardenclyffe.main.tasks.create_elastic_transcoder_job
+
+    def post_process(self):
+        return self.operation.video.handle_mediathread_update()
 
 
 class CopyFromS3ToCunixOperation(OperationType):
@@ -928,6 +951,7 @@ OPERATION_TYPE_MAPPER = {
     'save file to S3': SaveFileToS3Operation,
     'upload to youtube': UploadToYoutubeOperation,
     'submit to mediathread': SubmitToMediathreadOperation,
+    'update mediathread': UpdateMediathreadOperation,
     'pull from s3 and upload to youtube':
     PullFromS3AndUploadToYoutubeOperation,
     'create elastic transcoder job': CreateElasticTranscoderJobOperation,

--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -277,6 +277,23 @@ class Video(TimeStampedModel):
                 return [o]
         return []
 
+    def create_mediathread_update(self):
+        """ add a temporary File that indicates that an update to Meth
+        is expected """
+        return File.objects.create(
+            video=self,
+            label="mediathread update",
+            filename="",
+            location_type='mediathreadupdate'
+        )
+
+    def has_mediathread_update(self):
+        return self.file_set.filter(
+            location_type="mediathreadupdate").count() > 0
+
+    def clear_mediathread_update(self):
+        self.file_set.filter(location_type="mediathreadupdate").delete()
+
     def cuit_file(self):
         try:
             return self.file_set.filter(location_type="cuit")[0]

--- a/wardenclyffe/main/tests/test_models.py
+++ b/wardenclyffe/main/tests/test_models.py
@@ -350,6 +350,17 @@ class MediathreadVideoTest(TestCase):
         f = CUITFLVFileFactory()
         assert f.video.cuit_file() == f
 
+    def test_mediathread_update(self):
+        v = VideoFactory()
+        # none to start with
+        self.assertFalse(v.has_mediathread_update())
+        # create one
+        v.create_mediathread_update()
+        self.assertTrue(v.has_mediathread_update())
+        # clear it
+        v.clear_mediathread_update()
+        self.assertFalse(v.has_mediathread_update())
+
 
 class MissingDimensionsTest(TestCase):
     """ test the behavior for a video that has a source file, but

--- a/wardenclyffe/main/tests/test_models.py
+++ b/wardenclyffe/main/tests/test_models.py
@@ -330,6 +330,14 @@ class MediathreadVideoTest(TestCase):
         f = CUITFLVFileFactory()
         assert not f.video.is_mediathread_submit()
 
+    def test_has_mediathread_asset_negative(self):
+        f = CUITFLVFileFactory()
+        self.assertFalse(f.video.has_mediathread_asset())
+
+    def test_has_mediathread_asset_positive(self):
+        f = FileFactory(location_type="mediathread")
+        self.assertTrue(f.video.has_mediathread_asset())
+
     def test_mediathread_submit(self):
         f = MediathreadFileFactory()
         assert f.video.mediathread_submit() == (None, None, None)

--- a/wardenclyffe/main/tests/test_views.py
+++ b/wardenclyffe/main/tests/test_views.py
@@ -250,8 +250,11 @@ class SimpleTest(TestCase):
 
     def test_flv_to_mp4_convert(self):
         v = VideoFactory()
+        FileFactory(video=v, location_type="mediathread", label="mediathread")
+        self.c.login(username=self.u.username, password="bar")
         response = self.c.post(reverse('video-flv-to-mp4', args=[v.pk]))
         self.assertEquals(response.status_code, 302)
+        self.assertTrue(v.has_mediathread_update())
 
 
 class TestSurelink(TestCase):

--- a/wardenclyffe/main/views.py
+++ b/wardenclyffe/main/views.py
@@ -764,6 +764,8 @@ class VideoYoutubeUploadView(StaffMixin, View):
 class FlvToMp4View(StaffMixin, View):
     def post(self, request, id):
         video = get_object_or_404(Video, id=id)
+        if video.has_mediathread_asset():
+            video.create_mediathread_update()
         if video.has_s3_source():
             # we don't need to pull down the flv, there's
             # already a copy in S3. instead, just

--- a/wardenclyffe/mediathread/tasks.py
+++ b/wardenclyffe/mediathread/tasks.py
@@ -1,4 +1,5 @@
 import requests
+import waffle
 import wardenclyffe.main.models
 from django.conf import settings
 from django_statsd.clients import statsd
@@ -114,6 +115,9 @@ def submit_to_mediathread(operation):
 
 
 def update_mediathread(operation):
+    if not waffle.switch_is_active('mediathread_update'):
+        print("mediathread updates are disabled")
+        return ("complete", "mediathread updates are temporarily disabled")
     statsd.incr("mediathread.tasks.update_mediathread")
     video = operation.video
     mediathread_secret = settings.MEDIATHREAD_SECRET

--- a/wardenclyffe/mediathread/tasks.py
+++ b/wardenclyffe/mediathread/tasks.py
@@ -51,6 +51,21 @@ def mediathread_submit_params(video, course_id, username, mediathread_secret,
     return params
 
 
+def mediathread_update_params(video, mediathread_secret):
+    params = {
+        'secret': mediathread_secret,
+        "metadata-uuid": video.uuid,
+        "metadata-wardenclyffe-id": str(video.id),
+        "metadata-tag": "update",
+    }
+    # the thumbnail may also have changed
+    params['thumb'] = video.cuit_poster_url() or video.poster_url()
+    # only handle the non-audio parameter. afaik, we didn't do audio
+    # conversions with the flv, so they shouldn't ever be converted
+    params['mp4_pseudo'] = video.h264_secure_stream_url()
+    return params
+
+
 def submit_to_mediathread(operation):
     statsd.incr("mediathread.tasks.submit_to_mediathread")
     params = loads(operation.params)
@@ -96,3 +111,27 @@ def submit_to_mediathread(operation):
     else:
         statsd.incr("mediathread.tasks.submit_to_mediathread.failure")
         return ("failed", "mediathread rejected submission")
+
+
+def update_mediathread(operation):
+    statsd.incr("mediathread.tasks.update_mediathread")
+    video = operation.video
+    mediathread_secret = settings.MEDIATHREAD_SECRET
+
+    # assume that width/height stay the same
+    # so we just need the new URL and the asset ID
+    if not video.mediathread_url():
+        statsd.incr(
+            "mediathread.tasks.update_mediathread.failure.video_url")
+        return ("failed", "no video URL")
+
+    params = mediathread_update_params(video, mediathread_secret)
+
+    r = requests.post(video.mediathread_asset_url() + "update/", params)
+    if r.status_code == 200:
+        return ("complete", "")
+    else:
+        statsd.incr("mediathread.tasks.update_mediathread.failure")
+        print(r.status_code)
+        print(r.content)
+        return ("failed", "mediathread rejected update")


### PR DESCRIPTION
After performing an FLV -> MP4 conversion, if the video has an associated Mediathread asset, we send a POST over there to inform it of the new URL.

The update logic does not yet exist on the Mediathread side, so it will need to be implemented before we can turn this feature on (it's behind a waffle switch).

The new bits in `wardenclyffe/mediathread/tasks.py` will be useful for looking at to implement that.

As it is currently implemented:

* it gets the mediathread asset URL, eg `https://mediathread.ccnmtl.columbia.edu/asset/1234/`, sticks `update/` on the end and makes a `POST` request there
* the parameters in that request roughly mirror the params that are sent to `/save/` when a new video is created, but stripped down to only the fields that would change as a result of the conversion (ie, we expect all the metadata and size info to stay the same)

Any of that we can definitely change if we think a different endpoint or parameter setup would make implementation of the Meth side simpler.