### PR TITLE
add s3serve view

### DIFF
--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -114,6 +114,17 @@ class Video(TimeStampedModel):
     def has_s3_source(self):
         return self.s3_file() is not None
 
+    def s3_transcoded(self):
+        r = self.file_set.filter(
+            location_type='s3', label="transcoded 480p file (S3)")
+        if r.count():
+            return r[0]
+        else:
+            return None
+
+    def has_s3_transcoded(self):
+        return self.s3_transcoded() is not None
+
     def s3_key(self):
         t = self.s3_file()
         if t:

--- a/wardenclyffe/main/tests/test_models.py
+++ b/wardenclyffe/main/tests/test_models.py
@@ -186,6 +186,16 @@ class EmptyVideoTest(TestCase):
         ops = f.video.handle_mediathread_submit()
         self.assertEqual(len(ops), 0)
 
+    def test_s3_transcoded_none(self):
+        f = MediathreadSubmitFileFactory()
+        self.assertIsNone(f.video.s3_transcoded())
+        self.assertFalse(f.video.has_s3_transcoded())
+
+    def test_s3_transcoded_exists(self):
+        f = S3FileFactory(label="transcoded 480p file (S3)")
+        self.assertIsNotNone(f.video.s3_transcoded())
+        self.assertTrue(f.video.has_s3_transcoded())
+
 
 class FileTest(TestCase):
     def test_set_metadata(self):

--- a/wardenclyffe/main/views.py
+++ b/wardenclyffe/main/views.py
@@ -640,6 +640,12 @@ class VideoView(StaffMixin, DetailView):
     context_object_name = "video"
 
 
+class VideoS3Serve(StaffMixin, DetailView):
+    template_name = "main/video_s3serve.html"
+    model = Video
+    context_object_name = "video"
+
+
 class FileView(StaffMixin, TemplateView):
     template_name = 'main/file.html'
 

--- a/wardenclyffe/templates/main/video_s3serve.html
+++ b/wardenclyffe/templates/main/video_s3serve.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% load static %}
+{% load waffle_tags %}
+{% load markup %}
+{% load oembed_tags %}
+
+{% block js %}
+    <link href="https://vjs.zencdn.net/5.4.6/video-js.min.css" rel="stylesheet">
+    <script src="https://vjs.zencdn.net/5.4.6/video.min.js"></script>
+{% endblock %}
+
+{% block content %}
+    <p>In Collection: <a href="{{video.collection.get_absolute_url}}">{{video.collection.title}}</a></p>
+    <h1>{{video.title}}</h1>
+
+    {% if video.has_s3_transcoded %}
+        <video id="video-{{video.pk}}" class="video-js vjs-default-skin"
+               controls preload="auto" width="640" height="480"
+               {% with video.poster as poster %}
+               {% if poster.dummy %}
+            poster="{% static 'img/vidthumb_480x360.jpg' %}"
+               {% else %}
+            poster="{{poster.image.src}}"
+               {% endif %}
+               {% endwith %}               
+               data-setup='{"example_option":true}'>
+            <source src="{{video.s3_transcoded.s3_download_url}}" type="video/mp4" />
+            <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
+        </video>
+    {% else %}
+    <p>No S3 transcoded file</p>
+    {% endif %}
+{% endblock %}

--- a/wardenclyffe/urls.py
+++ b/wardenclyffe/urls.py
@@ -42,6 +42,7 @@ urlpatterns = [
         views.RemoveTagFromCollectionView.as_view()),
     url(r'^collection/(?P<id>\d+)/rss/$', CollectionFeed()),
     url(r'^video/(?P<pk>\d+)/edit/$', views.EditVideoView.as_view()),
+    url(r'^video/(?P<pk>\d+)/s3serve/$', views.VideoS3Serve.as_view()),
     url(r'^video/(?P<id>\d+)/delete/$', views.DeleteVideoView.as_view()),
     url(r'^video/(?P<id>\d+)/remove_tag/(?P<tagname>\w+)/$',
         views.RemoveTagFromVideoView.as_view()),


### PR DESCRIPTION
Beginning to play around with pointing a player straight at the encoded
video on S3.

S3 does "pseudo-streaming" with range headers basically the same as our
FLV solution does, so this could potentially be "good enough" from a
performance perspective.

Right now, just instantiating a video.js player that loads the S3
URL (signed with a 1-hour expiration).

I'll also want to play around with setting up a cloudfront distribution
in front of it to see if that changes things. I think I can also
restrict based on IP address, so that's worth investigating.

I also plan on making an iframe-able version of this with a similar auth
scheme to surelink. Ie, a proof of concept with WC+S3 as the secure
streaming video server. If it seems workable, we can split it out into
its own service.

For now, this is just at a '/s3serve/' URL without anything linking to
it, so no one is likely to stumble on this unless we point them at
it. This should be OK to get started evaluating this approach and doing
some gap analysis against the h264/surelink setup.