### PR TITLE
move update mediathread operation after s3 to cunix

### DIFF
--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -875,9 +875,6 @@ class CreateElasticTranscoderJobOperation(OperationType):
         import wardenclyffe.main.tasks
         return wardenclyffe.main.tasks.create_elastic_transcoder_job
 
-    def post_process(self):
-        return self.operation.video.handle_mediathread_update()
-
 
 class CopyFromS3ToCunixOperation(OperationType):
     def get_task(self):
@@ -885,7 +882,9 @@ class CopyFromS3ToCunixOperation(OperationType):
         return wardenclyffe.main.tasks.copy_from_s3_to_cunix
 
     def post_process(self):
-        return self.operation.video.handle_mediathread_submit()
+        ops = self.operation.video.handle_mediathread_submit()
+        ops.append(self.operation.video.handle_mediathread_update())
+        return ops
 
 
 class CopyFlvFromCunixToS3Operation(OperationType):


### PR DESCRIPTION
ensure that the video has not only been processed, but has made it up to
cunix before trying to update the mediathread entry