### PR TITLE
handle 404s on update mediathread

### DIFF
--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -244,6 +244,9 @@ class Video(TimeStampedModel):
         return self.file_set.filter(
             location_type="mediathread").first().url
 
+    def remove_mediathread_asset(self):
+        return self.file_set.filter(location_type="mediathread").delete()
+
     def mediathread_submit(self):
         for f in self.file_set.filter(location_type="mediathreadsubmit"):
             return (f.get_metadata("set_course"),

--- a/wardenclyffe/main/tests/test_models.py
+++ b/wardenclyffe/main/tests/test_models.py
@@ -348,6 +348,12 @@ class MediathreadVideoTest(TestCase):
         f = FileFactory(location_type="mediathread")
         self.assertTrue(f.video.has_mediathread_asset())
 
+    def test_remove_mediathread_asset(self):
+        f = FileFactory(location_type="mediathread")
+        self.assertTrue(f.video.has_mediathread_asset())
+        f.video.remove_mediathread_asset()
+        self.assertFalse(f.video.has_mediathread_asset())
+
     def test_mediathread_submit(self):
         f = MediathreadFileFactory()
         assert f.video.mediathread_submit() == (None, None, None)

--- a/wardenclyffe/mediathread/tasks.py
+++ b/wardenclyffe/mediathread/tasks.py
@@ -137,6 +137,14 @@ def update_mediathread(operation):
     r = requests.post(mediathread_base + '/update/', params)
     if r.status_code == 200:
         return ("complete", "")
+    elif r.status_code == 404:
+        print("Mediathread responded with a 404")
+        # mediathread doesn't have this asset anymore. that's fine.
+        # we should delete the asset on our end while we're at it
+        # since it is outdated.
+        video.remove_mediathread_asset()
+        # from an operation perspective, we consider this successful
+        return ("complete", "")
     else:
         statsd.incr("mediathread.tasks.update_mediathread.failure")
         print(r.status_code)


### PR DESCRIPTION
If we update the mediathread asset but mediathread responds with a 404,
that's ok. It just means our link is outdated, so we can clear it out.