### PR TITLE
simplify flv filename handling a bit

### DIFF
--- a/wardenclyffe/main/management/commands/import_flv_and_convert.py
+++ b/wardenclyffe/main/management/commands/import_flv_and_convert.py
@@ -25,13 +25,17 @@ class Command(BaseCommand):
         user = User.objects.get(username=uni)
         collection = Collection.objects.get(id=collection_id)
 
+        full_filename = flv
+        if not full_filename.startswith('/www/data/ccnmtl/'):
+            full_filename = '/www/data/ccnmtl/' + full_filename
+
         # create basic video
         v = Video.objects.simple_create(collection, flv, uni)
 
         # create an FLV File for the video
         File.objects.create(
             video=v,
-            filename=flv,
+            filename=full_filename,
             location_type='cuit',
             label='CUIT FLV',
         )


### PR DESCRIPTION
just make it so I don't have to type in the full path of the flv
filename and can instead copy in the filename as it comes in from the
streamlogs. (also makes the title of the video a little less obnoxious)