### PR TITLE
extract metadata after upload to s3

### DIFF
--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -901,10 +901,19 @@ class CopyFlvFromCunixToS3Operation(OperationType):
         if 's3_key' not in params:
             return []
         key = params['s3_key']
-
-        return [
+        ops = [
             operation.video.make_create_elastic_transcoder_job_operation(
                 key=key, user=operation.owner)]
+        if operation.video.source_file() is None:
+            # no source file implies that the metadata has not been extracted
+            operation.video.make_source_file(key)
+            o = operation
+            ops.extend(
+                o.video.make_pull_from_s3_and_extract_metadata_operation(
+                    key=key,
+                    user=operation.owner,
+                ))
+        return ops
 
 
 class AudioEncodeOperation(OperationType):


### PR DESCRIPTION
this still has to happen on the flv -> mp4 conversions, especially if
the video is ever going to make it up to mediathread.

So, after uploading to s3, we just check whether there is already a
source file attached to the video. if not, we know we need to extract
metadata.