### PR TITLE
link directly to videos on streamlog list

### DIFF
--- a/wardenclyffe/templates/streamlogs/streamlog_list.html
+++ b/wardenclyffe/templates/streamlogs/streamlog_list.html
@@ -23,6 +23,7 @@
             <tr>
                 <th>timestamp</th>
                 <th>filename</th>
+                <th>video</th>
             </tr>
         </thead>
         <tbody>
@@ -30,6 +31,13 @@
         <tr>
             <td><a href="{% url 'streamlogs-detail' object.pk %}">{{object.request_at}}</a></td>
             <td><tt>{{object.filename}}</tt></td>
+            <td>
+                {% with video=object.video %}
+                    {% if video %}
+                        <a href="{% url 'video-details' video.pk %}">{{video.title}}</a>
+                    {% endif %}
+                {% endwith %}
+            </td>
         </tr>
     {% endfor %}
         </tbody>


### PR DESCRIPTION
if the streamed file has a corresponding video in WC, link directly to
it from the streamlog list page. This will make it one step faster to
work through the remainder FLVs.