### PR TITLE
simple interface to import flvs directly from streamlog list

### DIFF
--- a/wardenclyffe/main/tests/test_views.py
+++ b/wardenclyffe/main/tests/test_views.py
@@ -749,3 +749,19 @@ class TestKeyFromS3Url(TestCase):
             key_from_s3url(s3url),
             "2016/04/18/46d54344-d228-4315-83ed-c0361dcac47c.mp3",
         )
+
+
+class FLVImportTest(TestCase):
+    def setUp(self):
+        self.u = UserFactory()
+        self.u.set_password("bar")
+        self.u.save()
+        self.c = Client()
+        self.c.login(username=self.u.username, password="bar")
+        self.collection = CollectionFactory()
+
+    def test_post(self):
+        with self.settings(
+                FLV_IMPORT_COLLECTION_ID=self.collection.id):
+            r = self.c.post(reverse("import-flv"), dict(flv="file.flv"))
+            self.assertEqual(r.status_code, 302)

--- a/wardenclyffe/settings_production.py
+++ b/wardenclyffe/settings_production.py
@@ -19,6 +19,9 @@ FFMPEG_PATH = "/usr/local/bin/ffmpeg"
 IMAGES_BUCKET = "ccnmtl-wardenclyffe-images-prod"
 IMAGES_URL_BASE = "https://d369ay3g98xik5.cloudfront.net/"
 
+# id of the default collection to put imported FLVs into
+FLV_IMPORT_COLLECTION_ID = 30
+
 INSTALLED_APPS += [
     'opbeat.contrib.django',
 ]

--- a/wardenclyffe/settings_shared.py
+++ b/wardenclyffe/settings_shared.py
@@ -86,6 +86,7 @@ H264_PUBLIC_STREAM_DIRECTORY = "/media/h264/ccnmtl/public/"
 H264_PUBLIC_STREAM_DIRECTORY = "/media/h264/ccnmtl/public/"
 H264_PUBLIC_STREAM_BASE = "http://stream.ccnmtl.columbia.edu/public/"
 
+CUNIX_BROADCAST_BASE = "/www/data/ccnmtl/"
 CUNIX_BROADCAST_DIRECTORY = "/www/data/ccnmtl/broadcast/"
 CUNIX_BROADCAST_URL = "http://ccnmtl.columbia.edu/broadcast/"
 CUNIX_SECURE_DIRECTORY = "/www/data/ccnmtl/broadcast/secure/"

--- a/wardenclyffe/templates/streamlogs/streamlog_list.html
+++ b/wardenclyffe/templates/streamlogs/streamlog_list.html
@@ -35,6 +35,11 @@
                 {% with video=object.video %}
                     {% if video %}
                         <a href="{% url 'video-details' video.pk %}">{{video.title}}</a>
+                    {% else %}
+                        <form action="{% url 'import-flv' %}" method="POST">
+                            <input type="hidden" name="flv" value="{{object.filename}}" />
+                            <input type="submit" value="import flv" />
+                        </form>
                     {% endif %}
                 {% endwith %}
             </td>

--- a/wardenclyffe/urls.py
+++ b/wardenclyffe/urls.py
@@ -105,6 +105,7 @@ urlpatterns = [
     url(r'^video/(?P<id>\d+)/add_file/$', views.VideoAddFileView.as_view()),
     url(r'^video/(?P<id>\d+)/select_poster/(?P<image_id>\d+)/$',
         views.VideoSelectPosterView.as_view()),
+    url(r'importflv/$', views.ImportFlv.as_view(), name='import-flv'),
     url(r'^search/$', views.SearchView.as_view()),
     url(r'^uuid_search/$', views.UUIDSearchView.as_view()),
     url(r'^api/tagautocomplete/$', views.TagAutocompleteView.as_view()),


### PR DESCRIPTION
basically just took the manage command and exposed it as a button on the
streamlog list page. So we can pull up the list, have a direct link to
the video if it is already in WC, or press a button to do the import if
it isn't.