### PR TITLE
strip out stray characters from surelink dimensions

### DIFF
--- a/wardenclyffe/main/tests/test_views.py
+++ b/wardenclyffe/main/tests/test_views.py
@@ -307,6 +307,32 @@ class TestSurelink(TestCase):
         assert "file=/media/h264/ccnmtl/" not in response.content
         assert "file=/course" in response.content
 
+    def test_file_surelink_extra_chars_in_dimensions(self):
+        """ regression test for PMT #87084 """
+        public_file = FileFactory(
+            filename=("/media/h264/ccnmtl/public/"
+                      "courses/56d27944-4131-11e1-8164-0017f20ea192"
+                      "-Mediathread_video_uploaded_by_mlp55.mp4"))
+        response = self.c.get("/file/%d/" % public_file.id)
+        self.assertEquals(response.status_code, 200)
+
+        response = self.c.get(
+            "/file/%d/surelink/" % public_file.id,
+            {'file': public_file.filename,
+             'captions': '',
+             'poster': ('http://wardenclyffe.ccnmtl.columbia.edu/'
+                        'uploads/images/11213/00000238.jpg'),
+             'width': "480-",
+             'height': " 720 ",
+             'protection': 'mp4_public_stream',
+             'authtype': '',
+             'player': 'v4',
+             })
+        self.assertEquals(response.status_code, 200)
+        assert "&lt;iframe" in response.content
+        assert "file=/media/h264/ccnmtl/" not in response.content
+        assert "file=/course" in response.content
+
 
 class TestFeed(TestCase):
     def test_rss_feed(self):


### PR DESCRIPTION
fixes this sentry issue:
https://sentry.io/columbia-ctl/wardenclyffe/issues/188955142/

which appears to be due to the user entering '480-' in a textbox instead
of just '480'. Ideally, this would be caught on the client side, but
since this is mostly an internal tool, I think it's fine to just strip
out anything non-numeric that comes in.