### PR TITLE
remove vestigial doctests

### DIFF
--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -38,19 +38,9 @@ class Collection(TimeStampedModel):
     tags = TaggableManager(blank=True)
 
     def __unicode__(self):
-        """
-        >>> c = Collection.objects.create(title="foo")
-        >>> str(c)
-        'foo'
-        """
         return self.title
 
     def get_absolute_url(self):
-        """
-        >>> c = Collection.objects.create(title="foo")
-        >>> c.get_absolute_url().startswith("/collection/")
-        True
-        """
         return "/collection/%d/" % self.id
 
     def add_video_form(self):
@@ -149,23 +139,9 @@ class Video(TimeStampedModel):
         return ""
 
     def get_absolute_url(self):
-        """
-        >>> c = Collection.objects.create(title="foo")
-        >>> v = Video.objects.create(collection=c, title="bar")
-        >>> v.get_absolute_url().startswith("/video/")
-        True
-        """
         return "/video/%d/" % self.id
 
     def get_oembed_url(self):
-        """
-        >>> c = Collection.objects.create(title="foo")
-        >>> v = Video.objects.create(collection=c, title="bar")
-        >>> v.get_oembed_url().startswith("/video/")
-        True
-        >>> v.get_oembed_url().endswith("/oembed/")
-        True
-        """
         return "/video/%d/oembed/" % self.id
 
     def add_file_form(self, data=None):


### PR DESCRIPTION
when WC was originally written, we were playing around with inline
doctests. The current test runner doesn't execute them though so they
don't really serve any purpose anymore. In particular, since they are
pretty much all on relatively trivial methods, they also aren't really
helping with understandability either. So currently they are just noise
and should probably be removed.