### PR TITLE
Fix unboundlocalerror sentry 193285033

### DIFF
--- a/wardenclyffe/main/tasks.py
+++ b/wardenclyffe/main/tasks.py
@@ -41,9 +41,10 @@ def process_operation(self, operation_id, **kwargs):
     print("process_operation(%s)" % (operation_id))
     try:
         operation = Operation.objects.get(id=operation_id)
-        operation.process()
     except Operation.DoesNotExist as exc:
         handle_operation_does_not_exist(self, exc)
+    try:
+        operation.process()
     except Exception as exc:
         print("Exception:")
         print(str(exc))


### PR DESCRIPTION
sentry: https://sentry.io/columbia-ctl/wardenclyffe/issues/193285033/

This splits out the retrieval of the Operation object from processing it. The exception we see in Sentry is happening because the `Operation.objects.get()` is raising the exception, so `operation` doesn't yet exist when it gets to the catch.

This should fix the exact exception we saw in Sentry there, though it doesn't really address the root issue. The `UnboundLocalError` is masking the real problem though, so we need to deal with it to see what's actually going wrong (basically, somewhere in the code, an Operation object is being passed in instead of an integer id).