### PR TITLE
include libffi-dev in docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ celerybeat-schedule
 client_secrets.json
 youtube_oauth.json
 node_modules
+wheelhouse

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:trusty
 RUN apt-get update
 RUN apt-get install python-ldap libldap2-dev libsasl2-dev \
     python-all-dev libxml2-dev libxslt1-dev libjpeg-dev \
-    python-tk liblcms1 libexif-dev libexif12 libfontconfig1-dev \
+    python-tk liblcms1 libexif-dev libexif12 libffi-dev libfontconfig1-dev \
     libfreetype6-dev liblcms1-dev libxft-dev python-imaging \
     python-beautifulsoup python-dev libssl-dev gcc \
     build-essential binutils libpq-dev postgresql-client -y


### PR DESCRIPTION
python 'cryptography' library won't install without it.