### PR TITLE
delete file from CUNIX

### DIFF
--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -358,6 +358,10 @@ class Video(TimeStampedModel):
         params = dict(file_id=file_id)
         return self.make_op(user, params, action="copy from s3 to cunix")
 
+    def make_delete_from_cunix_operation(self, file_id, user):
+        params = dict(file_id=file_id)
+        return self.make_op(user, params, action="delete from cunix")
+
     def make_pull_thumbs_from_s3_operation(self, pattern, user):
         params = dict(pattern=pattern)
         return self.make_op(user, params, action="pull thumbs from s3")
@@ -864,6 +868,12 @@ class CopyFromS3ToCunixOperation(OperationType):
         return ops
 
 
+class DeleteFromCunixOperation(OperationType):
+    def get_task(self):
+        import wardenclyffe.main.tasks
+        return wardenclyffe.main.tasks.delete_from_cunix
+
+
 class CopyFlvFromCunixToS3Operation(OperationType):
     def get_task(self):
         import wardenclyffe.main.tasks
@@ -930,6 +940,7 @@ OPERATION_TYPE_MAPPER = {
     PullFromS3AndUploadToYoutubeOperation,
     'create elastic transcoder job': CreateElasticTranscoderJobOperation,
     'copy from s3 to cunix': CopyFromS3ToCunixOperation,
+    'delete from cunix': DeleteFromCunixOperation,
     'copy flv from cunix to s3': CopyFlvFromCunixToS3Operation,
     "audio encode": AudioEncodeOperation,
     "local audio encode": LocalAudioEncodeOperation,

--- a/wardenclyffe/main/views.py
+++ b/wardenclyffe/main/views.py
@@ -873,6 +873,17 @@ class ImportFlv(StaffMixin, View):
         return HttpResponseRedirect(v.get_absolute_url())
 
 
+@transaction.non_atomic_requests()
+class DeleteFromCunix(StaffMixin, View):
+    def post(self, request, pk):
+        f = get_object_or_404(File, pk=pk)
+        video = f.video
+        o = video.make_delete_from_cunix_operation(file_id=f.id,
+                                                   user=request.user)
+        tasks.process_operation.delay(o.id)
+        return HttpResponseRedirect(reverse('video-details', args=[video.id]))
+
+
 class AudioEncodeFileView(StaffMixin, View):
     def post(self, request, pk):
         f = get_object_or_404(File, pk=pk)

--- a/wardenclyffe/templates/main/file.html
+++ b/wardenclyffe/templates/main/file.html
@@ -120,6 +120,15 @@ S3 Key
 
 
 </div>
+
+<div id="delete-from-cunix">
+    <h2>Delete File From CUNIX</h2>
+
+    <form action="{% url 'delete-file-from-cunix' file.id %}" method="post">
+        <input type="submit" value="delete this file from CUNIX" />
+    </form>
+</div>
+
 {% endif %}
 
 

--- a/wardenclyffe/urls.py
+++ b/wardenclyffe/urls.py
@@ -59,6 +59,9 @@ urlpatterns = [
     url(r'^file/(?P<id>\d+)/$', views.FileView.as_view()),
     url(r'^file/(?P<pk>\d+)/audio/$', views.AudioEncodeFileView.as_view(),
         name='audio_encode_file'),
+    url(r'^file/(?P<pk>\d+)/delete_from_cunix/$',
+        views.DeleteFromCunix.as_view(),
+        name='delete-file-from-cunix'),
 
     url(r'^file/filter/$', views.FileFilterView.as_view()),
     url((r'^operation/(?P<uuid>[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-'


### PR DESCRIPTION
see PMT #110468

the eventual goal is to allow Mediathread to delete old files from cunix
when removing old courses. As a first step, we implement a manual delete
from cunix function so we can at least test and make sure that works
properly before setting up an API that mediathread can access.