### PR TITLE
expose API for cunix deletion

### DIFF
--- a/wardenclyffe/mediathread/auth.py
+++ b/wardenclyffe/mediathread/auth.py
@@ -1,0 +1,21 @@
+import hmac
+import hashlib
+from django.conf import settings
+
+
+class MediathreadAuthenticator(object):
+    def __init__(self, d):
+        self.nonce = d.get('nonce', '')
+        self.hmc = d.get('hmac', '')
+        self.set_course = d.get('set_course', '')
+        self.username = d.get('as')
+        self.redirect_to = d.get('redirect_url', '')
+
+    def is_valid(self):
+        verify = hmac.new(
+            settings.MEDIATHREAD_SECRET,
+            '%s:%s:%s' % (self.username, self.redirect_to,
+                          self.nonce),
+            hashlib.sha1
+        ).hexdigest()
+        return verify == self.hmc

--- a/wardenclyffe/urls.py
+++ b/wardenclyffe/urls.py
@@ -115,6 +115,8 @@ urlpatterns = [
     url(r'^api/subjectautocomplete/$',
         views.SubjectAutocompleteView.as_view()),
     url(r'^api/sns/$', views.SNSView.as_view()),
+    url(r'^api/cunixdelete/$', views.APICunixDelete.as_view(),
+        name='api-cunix-delete'),
     url(r'^celery/', include('djcelery.urls')),
     url('smoketest/', include('smoketest.urls')),
     url(r'^stats/$', TemplateView.as_view(template_name="main/stats.html")),


### PR DESCRIPTION
next step on PMT #110468

This exposes an API endpoint that mediathread can make a POST request to
when it wants to tell WC to delete a file off cunix.

We already have an auth setup for mediathread integration, so I re-used
that as much as possible for this endpoint. Since it's a slightly
different use-case, it's a little bit odd though, with a field
overloaded to have a different meaning.

The usual meth -> WC handoff is for a user going through the browser, so
the username and a post-upload redirect_to parameter is included in the
hmac.

The deletion would be happening from the backend, invisible to the user,
but the token approach is still useful, so we keep it. But instead of
using `redirect_to` as a location to send to afterwards, we just re-use
that field to hold the WC `video_id` of the video that we want cleared
off cunix.

So, to summarize, when meth wants to delete a file on cunix, it needs to
know the WC video_id (I think it tracks that already when a file has
been uploaded through WC). It should then make a POST request to
`/api/cunixdelete/` with the following (POST) parameters:

* `as` - the username/uni of the user that the deletion should run
  as (really just what WC will log on the operation)
* `redirect_to` - the WC `video_id`
* `nonce` - a random unique token
* `hmac` - the hmac constructed the usual way out of the shared secret,
  username, redirect_to, and nonce.

The response should be a 403 if something is wrong with the token, a 404
if either the video doesn't exist or it doesn't have an associated cunix
file, or a 200 if the deletion operation was successfully scheduled.

Since deletions don't actually happen in the request cycle, it may still
take a while for the file to actually be deleted. If the operation
fails, the user should get a notification through the usual emails.