### PR TITLE
remove opbeat

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -101,6 +101,5 @@ django-s3sign==0.1.3
 django-smtp-ssl==1.0
 urllib3==1.21.1
 certifi==2017.4.17
-opbeat==3.5.2
 
 ccnmtlsettings==1.3.0


### PR DESCRIPTION
I originally set up opbeat integration on a couple apps to see if we
liked it better than sentry. It doesn't seem to have gotten any traction
so I'm removing it.