### PR TITLE
Remove pycrypto dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,6 @@ pyasn1_modules==0.2.1
 rsa==3.4.2
 uritemplate==3.0.0
 google-api-python-client==1.6.6
-pycrypto==2.6.1
 enum34==1.1.6
 asn1crypto==0.24.0
 cryptography==2.2.2


### PR DESCRIPTION
Background: `pycrypto` needs to be removed or patched due to security vulnerability (https://security-tracker.debian.org/tracker/source-package/python-crypto).

A little sleuthing shows that `pycrypto` was added as a dependency back in 2011 for [paramiko 1.7.1.1](https://pypi.python.org/pypi/paramiko/1.7.7.1). The latest version [paramiko 2.4.1](https://pypi.python.org/pypi/paramiko/2.4.1) no longer requires this library. I also used [pipdeptree](https://pypi.python.org/pypi/pipdeptree/0.11.0) to map all the dependencies to further prove `pycrypto` is no longer needed. I think we're good with pulling this. I'll manually test once this is merged as well.