### PR TITLE
Integrate Mediathread upload with Panopto

### DIFF
--- a/wardenclyffe/main/tests/test_models.py
+++ b/wardenclyffe/main/tests/test_models.py
@@ -139,6 +139,9 @@ class EmptyVideoTest(TestCase):
     def test_has_flv(self):
         self.assertFalse(self.video.has_flv())
 
+    def test_has_panopto_source(self):
+        self.assertFalse(self.video.has_panopto_source())
+
     def test_has_mp4(self):
         self.assertFalse(self.video.has_mp4())
 
@@ -318,6 +321,10 @@ class MediathreadVideoTest(TestCase):
             "40e67868-41f1-11e1-aaa7-0017f20ea192-"
             "Mediathread_video_uploaded_by_anp8.flv")
 
+    def test_has_panopto_source(self):
+        f = FileFactory(location_type='panopto')
+        self.assertTrue(f.video.has_panopto_source())
+
     def test_mediathread_url(self):
         f = CUITFLVFileFactory(
             filename=("/www/data/ccnmtl/broadcast/secure/courses/"
@@ -331,6 +338,9 @@ class MediathreadVideoTest(TestCase):
                 "/OPTIONS/secure/courses/"
                 "40e67868-41f1-11e1-aaa7-0017f20ea192"
                 "-Mediathread_video_uploaded_by_anp8.flv"))
+
+        f = FileFactory(location_type='panopto', filename='foo')
+        self.assertEquals(f.video.mediathread_url(), 'foo')
 
     def test_poster_url(self):
         f = CUITFLVFileFactory()

--- a/wardenclyffe/main/views.py
+++ b/wardenclyffe/main/views.py
@@ -527,10 +527,10 @@ def upload(request):
     v.make_uploaded_source_file(key)
 
     if request.POST.get("submit_to_panopto", False):
-        folder_name = request.POST.get('folder_id', None)
+        folder = request.POST.get('folder', None)
         operations = [
             v.make_pull_from_s3_and_upload_to_panopto_operation(
-                v.id, folder_name, request.user)
+                v.id, folder, request.user)
         ]
     else:
         operations = v.initial_operations(key, request.user,

--- a/wardenclyffe/mediathread/tasks.py
+++ b/wardenclyffe/mediathread/tasks.py
@@ -41,6 +41,8 @@ def mediathread_submit_params(video, course_id, username, mediathread_secret,
         else:
             params['mp4_pseudo'] = video.h264_secure_stream_url()
         params["mp4-metadata"] = "w%dh%d" % (width, height)
+    elif video.has_panopto_source():
+        params['mp4_panopto'] = video.mediathread_url()
     elif video.mediathread_url():
         # try flv pseudo stream as a fallback
         params['flv_pseudo'] = video.mediathread_url()
@@ -80,10 +82,6 @@ def submit_to_mediathread(operation):
     mediathread_base = settings.MEDIATHREAD_BASE
 
     (width, height) = guess_dimensions(video, audio)
-    if not width or not height:
-        statsd.incr(
-            "mediathread.tasks.submit_to_mediathread.failure.dimensions")
-        return ("failed", "could not figure out dimensions")
     if not video.mediathread_url():
         statsd.incr(
             "mediathread.tasks.submit_to_mediathread.failure.video_url")

--- a/wardenclyffe/mediathread/tests/test_tasks.py
+++ b/wardenclyffe/mediathread/tests/test_tasks.py
@@ -1,7 +1,8 @@
 from django.test import TestCase
-from wardenclyffe.mediathread.tasks import mediathread_submit_params
+
 from wardenclyffe.main.tests.factories import (
-    VideoFactory, UserFactory, CUITFLVFileFactory)
+    VideoFactory, UserFactory, CUITFLVFileFactory, FileFactory)
+from wardenclyffe.mediathread.tasks import mediathread_submit_params
 
 
 class TestMediathreadSubmitParams(TestCase):
@@ -37,3 +38,17 @@ class TestMediathreadSubmitParams(TestCase):
         self.assertTrue('mp4_pseudo' not in p)
         self.assertTrue('flv_pseudo' in p)
         self.assertEqual(p['flv_pseudo-metadata'], 'w100h200')
+
+    def test_panopto(self):
+        f = FileFactory(location_type='panopto', filename='foo')
+        v = f.video
+        u = UserFactory()
+        p = mediathread_submit_params(
+            v, "a course id", u.username,
+            "a mediathread secret",
+            False, 100, 200
+        )
+        self.assertTrue('mp4_audio' not in p)
+        self.assertTrue('mp4_pseudo' not in p)
+        self.assertTrue('flv_pseudo' not in p)
+        self.assertTrue('mp4_panopto' in p)

--- a/wardenclyffe/mediathread/views.py
+++ b/wardenclyffe/mediathread/views.py
@@ -35,12 +35,11 @@ def mediathread(request):
     request.session['redirect_to'] = authenticator.redirect_to
     request.session['hmac'] = authenticator.hmc
     audio = request.GET.get('audio', False)
-    folder_name = request.GET.get('folder', '')
+    folder = request.GET.get('folder', '')
     template = 'mediathread/mediathread.html'
     return render(
         request, template,
-        dict(username=username, user=user, audio=audio,
-             folder_name=folder_name))
+        dict(username=username, user=user, audio=audio, folder=folder))
 
 
 @transaction.non_atomic_requests

--- a/wardenclyffe/templates/mediathread/mediathread.html
+++ b/wardenclyffe/templates/mediathread/mediathread.html
@@ -64,7 +64,7 @@
 {% if audio %}
                     <input type="hidden" name="audio" value="True" />
 {% endif %}
-                    <input type="hidden" name="folder" value="{{folder_name}}" />
+                    <input type="hidden" name="folder" value="{{folder}}" />
 
                     <div id="vitaldropform" class="adminformcontainer">
                         <table border="0" cellpadding="0" cellspacing="0" id="adminformtable" class="adminformtable"> 

--- a/wardenclyffe/templates/mediathread/mediathread.html
+++ b/wardenclyffe/templates/mediathread/mediathread.html
@@ -3,13 +3,13 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-	<title>Mediathread  &mdash; {% if audio %}Audio{% else %}Video{% endif %} Upload</title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <title>Mediathread  &mdash; {% if audio %}Audio{% else %}Video{% endif %} Upload</title>
 {% compress css %}
-	<link rel="stylesheet" href="{{STATIC_URL}}css/wardenclyffe.css?v=1" media="screen" />
-	<link rel="stylesheet" href="{{STATIC_URL}}css/print.css" media="print" />
+    <link rel="stylesheet" href="{{STATIC_URL}}css/wardenclyffe.css?v=1" media="screen" />
+    <link rel="stylesheet" href="{{STATIC_URL}}css/print.css" media="print" />
 {% endcompress %}
-	<link rel="shortcut icon" href="{{STATIC_URL}}img/favicon.ico" type="image/x-icon" />
+    <link rel="shortcut icon" href="{{STATIC_URL}}img/favicon.ico" type="image/x-icon" />
 
     {% include 'main/jquery.html' %}
 
@@ -26,13 +26,13 @@
 <body class="one_column fixed mediathread">
     <div id="container">
         <!-- ###### Site banner ###### -->
-		<div id="header">
-			<div id="standardnav_container">   
-				<div id="mediathread_logo">
-					<a href="http://mediathread.ccnmtl.columbia.edu/"><img src="{{STATIC_URL}}img/logo_mediathread_new.png" alt="mediathread logo" width="156" height="45"></a>
-				</div>
-			</div>
-		</div>
+        <div id="header">
+            <div id="standardnav_container">   
+                <div id="mediathread_logo">
+                    <a href="http://mediathread.ccnmtl.columbia.edu/"><img src="{{STATIC_URL}}img/logo_mediathread_new.png" alt="mediathread logo" width="156" height="45"></a>
+                </div>
+            </div>
+        </div>
 
         <!-- ###### Don't touch this ###### -->
         <div class="visualclear"></div>
@@ -42,12 +42,12 @@
             <h1>Mediathread {% if audio %}Audio{% else %}Video{% endif %} Upload</h1>
 
             <div id="admincontent" style="width: 600px;"> 
-            	<div id="admincontent-inner"> 
-            		<div id="admincontent-top"> 
-                		<div id="admincontent-top-inner"> 
-                			<div id="admincontent-top-body"></div> 
-                		</div> 
-            		</div> 
+                <div id="admincontent-inner"> 
+                    <div id="admincontent-top"> 
+                        <div id="admincontent-top-inner"> 
+                            <div id="admincontent-top-body"></div> 
+                        </div> 
+                    </div> 
                     <div style="padding: 5px 15px 0 15px;">
                         <p>Welcome, <b>{% if user.first_name %}{{user.first_name}}
                         {{user.last_name}}{% else %}{{user.username}}{% endif %}</b>.</p>
@@ -66,7 +66,7 @@
 {% endif %}
                     <div id="vitaldropform" class="adminformcontainer">
                         <table border="0" cellpadding="0" cellspacing="0" id="adminformtable" class="adminformtable"> 
-                        	<tr>
+                            <tr>
                                 <td class="step one">
                                     <img src="{{STATIC_URL}}img/steps.png" alt="step one"></img>
                                 </td>
@@ -85,24 +85,24 @@
                             </tr>
                             <tr style="height: 30px"><td></td></tr>
                         
-                        	<tr class="post-upload" style="display: none">
+                            <tr class="post-upload" style="display: none">
                                 <td class="step two">
                                     <img src="{{STATIC_URL}}img/steps.png" alt="step two"></img>
                                 </td>
-                        	    <td class="step">
+                                <td class="step">
                                     <h4>UPDATE the {% if audio %}audio{% else %}video{% endif %} title</h4>
                                     <input type="text" name="title" value="Mediathread {% if audio %}audio{% else %}video{% endif %} uploaded by {{user.username}}" size="50" />
                                 </td>
-                        	</tr> 
+                            </tr> 
                             <tr style="height: 30px"><td></td></tr>
-                        	<tr class="post-upload" style="display: none">
+                            <tr class="post-upload" style="display: none">
                                 <td class="step three">
                                     <img src="{{STATIC_URL}}img/steps.png" alt="step three"></img>
                                 </td>
                                 <td class="step three" colspan="2">
                                     <h4>UPLOAD the {% if audio %}audio{% else %}video{% endif %}</h4>
-                        	        <input type="submit" value="Upload" class="regButton" id="submit" disabled="disabled" />
-                        	   </td>
+                                    <input type="submit" value="Upload" class="regButton" id="submit" disabled="disabled" />
+                               </td>
                             </tr> 
                         
                         
@@ -116,12 +116,12 @@
                       <p>if you encounter a problem converting or uploading a {% if audio %}audio{% else %}video{% endif %}, please visit CCNMTL's Helpdesk <a href="http://support.ccnmtl.columbia.edu/knowledgebase">http://support.ccnmtl.columbia.edu/knowledgebase</a></p>
                     </div>
             
-            		<div id="admincontent-bottom"> 
-            		<div id="admincontent-bottom-inner"> 
-            			<div id="admincontent-bottom-body"></div> 
-            		</div> 
-            		</div> 
-            	</div><!-- End id="admincontent-inner" --> 
+                    <div id="admincontent-bottom"> 
+                    <div id="admincontent-bottom-inner"> 
+                        <div id="admincontent-bottom-body"></div> 
+                    </div> 
+                    </div> 
+                </div><!-- End id="admincontent-inner" --> 
             </div><!-- End id="admincontent" --> 
 
 </div>
@@ -130,8 +130,8 @@
 {% else %}
 {% include 'main/maintenance_mode.html' %}
 {% endflag %}
-	<!-- ###### Footer ###### -->
-	<div id="footer_m"><div></div>
+    <!-- ###### Footer ###### -->
+    <div id="footer_m"><div></div>
 
 </div>
 <script type="text/javascript">

--- a/wardenclyffe/templates/mediathread/mediathread.html
+++ b/wardenclyffe/templates/mediathread/mediathread.html
@@ -59,11 +59,13 @@
                         Any other video should be converted to a Quicktime-compatible format before uploading. Submitted files must be less than 2GB.</p>
                     {% endif %}
                     </div>
-            
+
                     <form action="post/" method="post" enctype="multipart/form-data">
 {% if audio %}
                     <input type="hidden" name="audio" value="True" />
 {% endif %}
+                    <input type="hidden" name="folder" value="{{folder_name}}" />
+
                     <div id="vitaldropform" class="adminformcontainer">
                         <table border="0" cellpadding="0" cellspacing="0" id="adminformtable" class="adminformtable"> 
                             <tr>


### PR DESCRIPTION
This PR sets up an alternative upload path to the Panopto system. If Mediathread passes over a Panopto folder uuid, Wardenclyffe will now push the file over to Panopto rather than the h264 streaming server.