### PR TITLE
Surelink Video conversion: handle possible duplications

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pyparsing==2.3.1
 six==1.12.0
 pytz==2018.9
 python-dateutil==2.7.5
-librabbitmq==2.0.0
+librabbitmq==1.6.1
 
 celery==3.1.26.post2 # pyup: <4.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pyparsing==2.3.1
 six==1.12.0
 pytz==2018.9
 python-dateutil==2.7.5
-librabbitmq==1.6.1
+librabbitmq==2.0.0
 
 celery==3.1.26.post2 # pyup: <4.0.0
 

--- a/wardenclyffe/main/views.py
+++ b/wardenclyffe/main/views.py
@@ -1482,7 +1482,8 @@ class SureLinkVideoView(TemplateView):
         )
 
     def add_video(self, fname, attrs):
-        collection = Collection.objects.get(title='Unclassified')
+        (collection, created) = Collection.objects.get_or_create(
+            title=settings.PANOPTO_COLLECTION)
         title = fname.split('/')[-1]
         v = Video.objects.simple_create(
             collection, title, settings.PANOPTO_MIGRATIONS_USER)
@@ -1531,7 +1532,7 @@ class SureLinkVideoView(TemplateView):
         stream_log = self.add_streamlog()
         video = stream_log.video()
 
-        if not video and fname:
+        if fname and not video and not stream_log.similar_video():
             video = self.find_video(fname)
 
         if video and video.youtube_file():

--- a/wardenclyffe/settings_shared.py
+++ b/wardenclyffe/settings_shared.py
@@ -142,3 +142,4 @@ PRIMARY_YOUTUBE_ACCOUNT = "ccnmtl@gmail.com"
 PANOPTO_LINK_URL = 'http://testserver/link/{}/'
 PANOPTO_EMBED_URL = 'http://testserver/embed/{}/'
 PANOPTO_MIGRATIONS_USER = 'migrations'
+PANOPTO_COLLECTION = 'Automatic Panopto Migrations'

--- a/wardenclyffe/streamlogs/tests/test_models.py
+++ b/wardenclyffe/streamlogs/tests/test_models.py
@@ -17,6 +17,12 @@ class StreamLogTest(TestCase):
             f.full_filename(),
             settings.CUNIX_BROADCAST_DIRECTORY + "foo/bar.flv")
 
+    def test_full_secure_filename(self):
+        s = StreamLogFactory(filename='broadcast/secure/foo/bar.flv')
+        self.assertEqual(
+            s.full_secure_filename(),
+            settings.CUNIX_SECURE_DIRECTORY + "foo/bar.flv")
+
     def test_video_no_match(self):
         f = StreamLogFactory()
         self.assertIsNone(f.video())
@@ -27,3 +33,10 @@ class StreamLogTest(TestCase):
             filename=settings.CUNIX_BROADCAST_DIRECTORY + "foo/bar.flv",
             location_type='cuit')
         self.assertEqual(s.video(), f.video)
+
+    def test_similar_video(self):
+        s = StreamLogFactory(filename="broadcast/foo/bar.flv")
+        self.assertFalse(s.similar_video())
+
+        FileFactory(filename="foo/bar.flv", location_type='cuit')
+        self.assertTrue(s.similar_video())


### PR DESCRIPTION
If a passed filename does not match perfectly, there's the possibility for multiple Panopto migrations to be requested. Adding two things to help:
* Add a match to the cunix "secure" directory
* Before submitting a "new" filename for conversion, see if there are any "similar" existing videos. If there are, don't go forward with the conversion.