### PR TITLE
Surelink automatic migrations: update file size if needed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -125,3 +125,5 @@ zeep==2.5.0 # pyup: <3.0.0
 pypanopto==0.0.6
 django-bootstrap4==0.0.7
 
+funcsigs==1.0.2
+mock==2.0.0


### PR DESCRIPTION
Existing videos with a CUIT file will not have the new `st_size` attribute populated. Take a minute to update the size. This will prevent very large video files from being migrated automagically.