### PR TITLE
Panopto Conversion endpoint

### DIFF
--- a/wardenclyffe/mediathread/tasks.py
+++ b/wardenclyffe/mediathread/tasks.py
@@ -65,9 +65,13 @@ def mediathread_update_params(video, mediathread_secret):
     params['asset-url'] = video.mediathread_asset_url()
     # the thumbnail may also have changed
     params['thumb'] = video.cuit_poster_url() or video.poster_url()
-    # only handle the non-audio parameter. afaik, we didn't do audio
-    # conversions with the flv, so they shouldn't ever be converted
-    params['mp4_pseudo'] = video.h264_secure_stream_url()
+
+    if video.has_panopto_source():
+        params['mp4_panopto'] = video.panopto_file().filename
+    else:
+        # only handle the non-audio parameter. afaik, we didn't do audio
+        # conversions with the flv, so they shouldn't ever be converted
+        params['mp4_pseudo'] = video.h264_secure_stream_url()
     return params
 
 

--- a/wardenclyffe/urls.py
+++ b/wardenclyffe/urls.py
@@ -1,12 +1,15 @@
-import django.views.static
-
+from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
-from django.conf import settings
+from django.views.generic import TemplateView
+import django.views.static
+
 from wardenclyffe.main.feeds import CollectionFeed
 import wardenclyffe.main.views as views
 import wardenclyffe.mediathread.views as mediathread_views
-from django.views.generic import TemplateView
+import wardenclyffe.panopto.views as panopto_views
+
+
 admin.autodiscover()
 
 urlpatterns = [
@@ -134,6 +137,9 @@ urlpatterns = [
     url(r'^api/sns/$', views.SNSView.as_view()),
     url(r'^api/cunixdelete/$', views.APICunixDelete.as_view(),
         name='api-cunix-delete'),
+    url(r'^api/panopto/convert/$',
+        panopto_views.APIPanoptoConversion.as_view(),
+        name='api-panopto-conversion'),
     url(r'^celery/', include('djcelery.urls')),
     url('smoketest/', include('smoketest.urls')),
     url(r'^stats/$', TemplateView.as_view(template_name="main/stats.html")),


### PR DESCRIPTION
Create a workflow to allow applications like Mediathread to kick off a media conversion.