### PR TITLE
StreamLog - tuning view to be more useful

### DIFF
--- a/wardenclyffe/streamlogs/templatetags/streamlog_tags.py
+++ b/wardenclyffe/streamlogs/templatetags/streamlog_tags.py
@@ -1,0 +1,12 @@
+from django import template
+
+from wardenclyffe.streamlogs.models import StreamLog
+
+
+register = template.Library()
+
+
+@register.simple_tag
+def find_video(filename):
+    sl = StreamLog(filename=filename)
+    return sl.video()

--- a/wardenclyffe/streamlogs/urls.py
+++ b/wardenclyffe/streamlogs/urls.py
@@ -1,11 +1,9 @@
 from django.conf.urls import url
 from django.contrib.auth.decorators import user_passes_test
-from django.views.generic.detail import DetailView
 
 from wardenclyffe.main.views import is_staff
-from wardenclyffe.streamlogs.models import StreamLog
 from wardenclyffe.streamlogs.views import (
-    LogView, ReportView, StreamLogListView)
+    LogView, ReportView, StreamLogListView, StreamLogDetailView)
 
 
 staff_only = user_passes_test(lambda u: is_staff(u))
@@ -17,8 +15,6 @@ urlpatterns = [
         name='streamlogs-report'),
     url(r'list/$', staff_only(
         StreamLogListView.as_view()), name='streamlogs-list'),
-    url(r'(?P<pk>\d+)/$', staff_only(
-        DetailView.as_view(
-            model=StreamLog,
-        )), name='streamlogs-detail'),
+    url(r'detail/$', staff_only(
+        StreamLogDetailView.as_view()), name='streamlogs-detail')
 ]

--- a/wardenclyffe/templates/streamlogs/streamlog_detail.html
+++ b/wardenclyffe/templates/streamlogs/streamlog_detail.html
@@ -2,7 +2,8 @@
 
 {% block content %}
     <p><a href="{% url 'streamlogs-list' %}">Back to List</a></p>
-    
+
+    {% with object=object_list.first %}
     <table>
         <tbody>
             <tr>
@@ -23,22 +24,38 @@
             <tr>
                 <th>Filename</th><td><tt>{{object.filename}}</tt></td>
             </tr>
-            <tr>
-                <th>Remote Address</th><td><tt>{{object.remote_addr}}</tt></td>
-            </tr>
-            <tr>
-                <th>Offset</th><td>{{object.offset}}</td>
-            </tr>
-            <tr>
-                <th>Referer</th><td><tt>{{object.referer}}</tt></td>
-            </tr>
-            <tr>
-                <th>User Agent</th><td>{{object.user_agent}}</td>
-            </tr>
-            <tr>
-                <th>Access Mode</th><td>{{object.access}}</td>
-            </tr>
         </tbody>
     </table>
-    
+    {% endwith %}
+
+    <!-- Results navigation  -->
+    <div class="visualclear"></div>
+    <div>
+        <div class="float-right">
+            {% include 'main/pagination.html' %}
+        </div>
+    </div>
+    <div class="visualclear"></div>
+    <br />
+
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Request At</th>
+                <th>Remote Address</th>
+                <th>User Agent</th>
+                <th>Referer</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for object in object_list %}
+            <tr>
+                <td style="width: 150px">{{object.request_at}}</td>
+                <td>{{object.remote_addr}}</td>
+                <td>{{object.user_agent}}</td>
+                <td>{{object.referer}}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
 {% endblock %}

--- a/wardenclyffe/templates/streamlogs/streamlog_list.html
+++ b/wardenclyffe/templates/streamlogs/streamlog_list.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load streamlog_tags %}
 
 {% block pagetitle %}Streaming Logs{% endblock %}
 
@@ -44,35 +45,34 @@
         <table class="table table-striped table-videos">
         <thead>
             <tr>
-                <th data-sort-by="request_at" >timestamp</th>
-                <th data-sort-by="filename">filename</th>
-                <th data-sort-by="video__title">video</th>
-                <th>migrated</th>
+                <th>Last View</th>
+                <th>Filename</th>
+                <th>Views</th>
+                <th>Video</th>
+                <th>Migrated</th>
             </tr>
         </thead>
         <tbody>
         {% for object in object_list %}
+            {% find_video object.filename as video %}
             <tr>
-                <td><a href="{% url 'streamlogs-detail' object.pk %}">{{object.request_at}}</a></td>
-                <td><tt>{{object.filename}}</tt></td>
+                <td style="width: 210px"><a>{{object.last_view}}</a></td>
+                <td><a href="{% url 'streamlogs-detail' %}?f={{object.filename}}">{{object.filename}}</a></td>
+                <td><tt>{{object.views}}</tt></td>
                 <td>
-                    {% with video=object.video %}
-                        {% if video %}
-                            <a href="{% url 'video-details' video.pk %}">{{video.title}}</a>
-                        {% else %}{% if '.flv' in object.filename %}
-                            <form action="{% url 'import-flv' %}" method="POST">
-                                <input type="hidden" name="flv" value="{{object.filename}}" />
-                                <input type="submit" value="import flv" />
-                            </form>
-                        {% endif %}{% endif %}
-                    {% endwith %}
+                    {% if video %}
+                        <a href="{% url 'video-details' video.pk %}">{{video.title}}</a>
+                    {% else %}{% if '.flv' in object.filename %}
+                        <form action="{% url 'import-flv' %}" method="POST">
+                            <input type="hidden" name="flv" value="{{object.filename}}" />
+                            <input type="submit" value="import flv" />
+                        </form>
+                    {% endif %}{% endif %}
                 </td>
                 <td>
-                    {% with video=object.video %}
-                        {% if video %}
-                            {{video.has_panopto_source}}
-                        {% endif %}
-                    {% endwith %}
+                    {% if video %}
+                        {{video.has_panopto_source}}
+                    {% endif %}
                 </td>
             </tr>
         {% endfor %}


### PR DESCRIPTION
Rather than just display lists and lists of StreamLogs, this PR modifies the StreamLog views to aggregate similar log material and provide counts. This should help us more easily identify media that is being used and needs to be migrated versus singular hits. The underlying detail view now shows the more granular information such as referer and user-agent.