### PR TITLE
Handle wedged Panopto job

### DIFF
--- a/wardenclyffe/panopto/tasks.py
+++ b/wardenclyffe/panopto/tasks.py
@@ -135,23 +135,24 @@ def verify_upload_to_panopto(operation):
     video_id = params['video_id']
     video = Video.objects.get(id=video_id)
 
-    upload_status = PanoptoUploadStatus()
-    upload_status.server = settings.PANOPTO_SERVER
-    upload_status.username = settings.PANOPTO_API_USER
-    upload_status.password = settings.PANOPTO_API_PASSWORD
-    upload_status.upload_id = params['upload_id']
+    if not video.has_panopto_source():
+        upload_status = PanoptoUploadStatus()
+        upload_status.server = settings.PANOPTO_SERVER
+        upload_status.username = settings.PANOPTO_API_USER
+        upload_status.password = settings.PANOPTO_API_PASSWORD
+        upload_status.upload_id = params['upload_id']
 
-    (state, panopto_id) = upload_status.check()
-    if state != 4:  # Panopto "Complete" State
-        raise Exception('Panopto is not yet finished.')
+        (state, panopto_id) = upload_status.check()
+        if state != 4:  # Panopto "Complete" State
+            raise Exception('Panopto is not yet finished.')
 
-    url = settings.PANOPTO_LINK_URL.format(panopto_id)
+        url = settings.PANOPTO_LINK_URL.format(panopto_id)
 
-    File.objects.create(
-        video=video, location_type='panopto', url=url,
-        filename=panopto_id, label='uploaded to panopto')
+        File.objects.create(
+            video=video, location_type='panopto', url=url,
+            filename=panopto_id, label='uploaded to panopto')
 
-    params['panopto_id'] = panopto_id
+    params['panopto_id'] = video.filename
     operation.params = dumps(params)
     operation.save()
 


### PR DESCRIPTION
Panopto jobs sometimes become wedged and never return a proper status. Put in an override to the verify job that will allow us to manually create the (successful) Panopto file and let the full flow continue.