### PR TITLE
Don't install typing on python >= 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: python
+
+# python 2.7.6 archive is only available on trusty
+dist: trusty
+
 python:
   - "2.7.6"
   - "2.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -96,7 +96,10 @@ django-jenkins==0.110.0
 django-appconf==1.0.3
 django-compressor==2.3
 django-extensions==2.1.9
-typing==3.7.4 # needed for django-extensions
+
+# needed for django-extensions
+typing==3.7.4; python_version < '3.5'
+
 django-markwhat==1.6.1
 tornado==4.5.3 # pyup: <5.0
 django-storages==1.7.1


### PR DESCRIPTION
This library shouldn't be installed on newer versions of python.

https://github.com/django-extensions/django-extensions/blob/master/setup.py#L125