### PR TITLE
travis: remove py2.7.6 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: python
-
-# python 2.7.6 archive is only available on trusty
-dist: trusty
-
+dist: xenial
 python:
-  - "2.7.6"
   - "2.7"
   - "3.6"
 before_install:


### PR DESCRIPTION
I'm migrating wardenclyffe to ubuntu 18, so we don't need to test on py2.7.6 anymore.