### PR TITLE
:arrow_up: oauth2client 4.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,10 +22,12 @@ librabbitmq==2.0.0
 
 celery==3.1.26.post2 # pyup: <4.0.0
 
-oauth2client==4.0.0 # pyup: <4.1
-pyasn1==0.4.6
-pyasn1_modules==0.2.6
-rsa==4.0
+jsonpickle==1.2  # oauth2client
+pyasn1==0.4.6  # oauth2client
+pyasn1_modules==0.2.6  # oauth2client
+rsa==4.0  # oauth2client
+oauth2client==4.1.3
+
 uritemplate==3.0.0
 google-api-python-client==1.7.11
 enum34==1.1.6; python_version < '3.4'


### PR DESCRIPTION
Apparently this library is deprecated, and we should upgrade to
google-auth and oauthlib: https://github.com/googleapis/oauth2client