### PR TITLE
:arrow_up: ccnmtlsettings 1.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -116,7 +116,7 @@ django-s3sign==0.1.4
 django-smtp-ssl==1.0
 certifi==2019.11.28  # sentry-sdk
 
-ccnmtlsettings==1.6.0
+ccnmtlsettings==1.8.0
 
 pbr==5.4.4
 PyYAML>=3.10.0 # MIT


### PR DESCRIPTION
Note: this will also pull in the 1.7.0 changes because it looks like wardenclyffe was still on 1.6.0:

* Add XFrameOptionsMiddleware
* Add SecurityMiddleware
* Flag CSRF and Session cookie as secure
* Flag CSRF and Session cookie as http only