### PR TITLE
Use base64.encodebytes() instead of encodestring()

### DIFF
--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -601,7 +601,7 @@ class S3File(FileType):
             smart_bytes(settings.AWS_SECRET_KEY),
             smart_bytes("".join(["GET\n\n\n", expiry, "\n", filename])),
             hashlib.sha1)
-        signature = quote_plus(base64.encodestring(h.digest()).strip())
+        signature = quote_plus(base64.encodebytes(h.digest()).strip())
         return "".join([
             "https://s3.amazonaws.com",
             filename,


### PR DESCRIPTION
This fixes an error on python 3.9:
  AttributeError: module 'base64' has no attribute 'encodestring'

base64.encodestring() is deprecated since 3.9:
https://docs.python.org/3.8/library/base64.html#base64.encodestring