### PR TITLE
Remove weekly s3 storage report

### DIFF
--- a/wardenclyffe/graphite/models.py
+++ b/wardenclyffe/graphite/models.py
@@ -1,6 +1,4 @@
-from django.conf import settings
-from wardenclyffe.main.models import Operation, File, Metadata
-import boto3
+from wardenclyffe.main.models import Operation, Metadata
 
 
 def operation_count_by_status():
@@ -15,24 +13,6 @@ def operation_count_by_status():
         'submitted': Operation.objects.filter(status="submitted").count(),
         'in progress': Operation.objects.filter(status="in progress").count(),
         'enqueued': Operation.objects.filter(status="enqueued").count()}
-
-
-def s3_stats():
-    """ return info on S3 storage usage
-    -> (int, int) for (# files, bytes)
-    """
-    total = 0
-    cnt = 0
-    s3 = boto3.resource(
-        's3', aws_access_key_id=settings.AWS_ACCESS_KEY,
-        aws_secret_access_key=settings.AWS_SECRET_KEY)
-    bucket = s3.Bucket(settings.AWS_S3_UPLOAD_BUCKET)
-    for f in File.objects.filter(location_type="s3"):
-        k = bucket.get_key(f.video.s3_key())
-        if k is not None:
-            total += k.size
-            cnt += 1
-    return (cnt, total)
 
 
 def minutes_video_stats():

--- a/wardenclyffe/graphite/tasks.py
+++ b/wardenclyffe/graphite/tasks.py
@@ -2,7 +2,7 @@ from celery.task.schedules import crontab
 from django_statsd.clients import statsd
 from wardenclyffe.celery import app
 from wardenclyffe.graphite.models import operation_count_by_status, \
-    minutes_video_stats, s3_stats
+    minutes_video_stats
 
 
 @app.task
@@ -23,14 +23,6 @@ def minutes_video():
     statsd.gauge("minutes_video", int(minutes_video_stats()))
 
 
-@app.task
-def weekly_s3_usage_report():
-    print("weekly_s3_report()")
-    (cnt, total) = s3_stats()
-    statsd.gauge("s3.total", total)
-    statsd.gauge("s3.cnt", cnt)
-
-
 @app.on_after_finalize.connect
 def setup_periodic_tasks(sender, **kwargs):
     sender.add_periodic_task(
@@ -40,7 +32,3 @@ def setup_periodic_tasks(sender, **kwargs):
     sender.add_periodic_task(
         crontab(hour='*', minute='*', day_of_week='*'),
         minutes_video.s())
-
-    sender.add_periodic_task(
-        crontab(hour=5, minute=0, day_of_week=0),
-        weekly_s3_usage_report.s())


### PR DESCRIPTION
The AWS management console does a very nice job at this. No need to add a graphite metric too.

This will resolve the need to update this code to boto3 as well.