### PR TITLE
Dependency fixes for celery 5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,10 @@ six==1.16.0
 pytz==2022.6
 python-dateutil==2.8.2
 
-vine==1.3.0
-amqp==2.6.1
+vine==5.0.0
+amqp==5.1.1
 kombu==5.3.0b2
+prompt-toolkit==3.0.32
 celery==5.2.7
 click>=8.0.3,<9.0
 click-didyoumean>=0.0.3


### PR DESCRIPTION
When running the `./ve/bin/celery` command, I found that prompt_toolkit is required, as well as vine/amqp updates.