### PR TITLE
Use github release of editdistance 0.6.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ flake8==7.0.0
 logilab-common==2.0.0
 astroid==3.0.0
 
-editdistance==0.6.2
+git+https://github.com/roy-ht/editdistance.git@v0.6.2
 
 pylint==3.0.0
 


### PR DESCRIPTION
This fixes a build failure for me on python 3.12. See: https://github.com/roy-ht/editdistance/issues/94