### PR TITLE
Update ffmpeg path

### DIFF
--- a/wardenclyffe/settings_production.py
+++ b/wardenclyffe/settings_production.py
@@ -15,7 +15,7 @@ locals().update(
 TMP_DIR = "/var/www/wardenclyffe/tmp/"
 WATCH_DIRECTORY = "/var/www/wardenclyffe/tmp/watch_dir/"
 
-FFMPEG_PATH = "/usr/local/bin/ffmpeg"
+FFMPEG_PATH = "/usr/bin/ffmpeg"
 
 IMAGES_BUCKET = "ccnmtl-wardenclyffe-images-prod"
 IMAGES_URL_BASE = "https://d369ay3g98xik5.cloudfront.net/"

--- a/wardenclyffe/settings_staging.py
+++ b/wardenclyffe/settings_staging.py
@@ -15,7 +15,7 @@ locals().update(
 TMP_DIR = "/var/www/wardenclyffe/tmp/"
 WATCH_DIRECTORY = "/var/www/wardenclyffe/tmp/watch_dir/"
 
-FFMPEG_PATH = "/usr/local/bin/ffmpeg"
+FFMPEG_PATH = "/usr/bin/ffmpeg"
 
 try:
     from wardenclyffe.local_settings import *  # noqa: F403


### PR DESCRIPTION
For some reason, wardenclyffe was set up to use an old, manually-compiled ffmpeg distributed with salt. This seems unnecessary so I've gotten rid of that, and just used ubuntu's ffmpeg.