### PR TITLE
Disable surelink

### DIFF
--- a/wardenclyffe/main/models.py
+++ b/wardenclyffe/main/models.py
@@ -722,7 +722,7 @@ class File(TimeStampedModel):
                 return None
 
     def surelinkable(self):
-        return self.location_type == 'cuit'
+        return False
 
     def has_cuit_poster(self):
         return File.objects.filter(video=self.video,

--- a/wardenclyffe/main/tests/test_models.py
+++ b/wardenclyffe/main/tests/test_models.py
@@ -34,7 +34,7 @@ class CUITFileTest(TestCase):
         assert self.file.is_cuit()
 
     def test_surelinkable(self):
-        assert self.file.surelinkable()
+        assert not self.file.surelinkable()
 
     def test_mediathread_url(self):
         self.assertEqual(


### PR DESCRIPTION
Our surelink library is archived:
https://github.com/ccnmtl/surelink

Because the servers which surelink runs on, it seems, are no longer in use. I want to start the slow migration off surelink, starting with this change, to see if this breaks anything.